### PR TITLE
rating:  color:  fc6423 -> color:  "#fc6423"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -654,7 +654,7 @@ gitalk:
 rating:
   enable: false
   id:     # <app_id>
-  color:  fc6423
+  color:  "#fc6423"
 
 # AddThis Share. See: https://www.addthis.com
 # Go to https://www.addthis.com/dashboard to customize your tools.


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [X] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [X] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [X] Tests for the changes was maked (for bug fixes / features).
   - [X] Muse | Mist have been tested.
   - [X] Pisces | Gemini have been tested.
- [X] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [X] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->
This patch if for consistency ONLY. All throughout `_config.yaml` color(s) are defined as `"#xxxxxx"`. The color for rating was `fc6423`. This does NOT cause an error, but for consistency it should be `"#fc6423"`.
`_config.yaml:` original:
```
rating:
  enable: false
  id:     26882
  color:  fc6423
```

My change:
```
rating:
  enable: false
  id:     26882
  color:  "#fc6423"
```


Issue resolved:

## What is the new behavior?
<!-- Description about this pull, in several words -->
Does not change behavior.

- Link to demo site with this changes:
- Screenshots with this changes:

### How to use?
Enable rating and you will see 5 stars at the bottom of a post with orange (#fc6423) stars.

In NexT `_config.yml`:
```yml

```
