### PR TITLE
Support preconnect hint for CDN

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,7 @@ minify: false
 preconnect:
   # If true, <link rel="preconnect" crossorigin> will be added to <head>.
   enable: false
-   # Serve <link rel="dns-prefetch"> as a fallback.
+  # Serve <link rel="dns-prefetch"> as a fallback.
   fallback: false
 
 # Define custom file paths.

--- a/_config.yml
+++ b/_config.yml
@@ -16,10 +16,6 @@ cache:
 # Remove unnecessary files after hexo generate.
 minify: false
 
-# Preconnect CDN for fonts and vendors.
-# For more information: https://www.w3.org/TR/resource-hints/#preconnect
-preconnect: false
-
 # Define custom file paths.
 # Create your custom files in site directory `source/_data` and uncomment needed files below.
 custom_file_path:
@@ -340,6 +336,10 @@ calendar:
 # Misc Theme Settings
 # See: https://theme-next.js.org/docs/theme-settings/miscellaneous
 # ---------------------------------------------------------------
+
+# Preconnect CDN for fonts and plugins.
+# For more information: https://www.w3.org/TR/resource-hints/#preconnect
+preconnect: false
 
 # Set the text alignment in posts / pages.
 text_align:

--- a/_config.yml
+++ b/_config.yml
@@ -18,11 +18,7 @@ minify: false
 
 # Preconnect CDN for fonts and vendors.
 # For more information: https://www.w3.org/TR/resource-hints/#preconnect
-preconnect:
-  # If true, <link rel="preconnect" crossorigin> will be added to <head>.
-  enable: false
-  # Serve <link rel="dns-prefetch"> as a fallback.
-  fallback: false
+preconnect: false
 
 # Define custom file paths.
 # Create your custom files in site directory `source/_data` and uncomment needed files below.

--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,14 @@ cache:
 # Remove unnecessary files after hexo generate.
 minify: false
 
+# Preconnect CDN for fonts and vendors.
+# For more information: https://www.w3.org/TR/resource-hints/#preconnect
+preconnect:
+  # If true, <link rel="preconnect" crossorigin> will be added to <head>.
+  enable: false
+   # Serve <link rel="dns-prefetch"> as a fallback.
+  fallback: false
+
 # Define custom file paths.
 # Create your custom files in site directory `source/_data` and uncomment needed files below.
 custom_file_path:

--- a/layout/_partials/head/head.njk
+++ b/layout/_partials/head/head.njk
@@ -3,6 +3,8 @@
 <meta name="theme-color" content="{{ theme.android_chrome_color }}">
 <meta name="generator" content="Hexo {{ hexo_version }}">
 
+{{ next_pre() }}
+
 {%- if theme.favicon.apple_touch_icon %}
   <link rel="apple-touch-icon" sizes="180x180" href="{{ url_for(theme.favicon.apple_touch_icon) }}">
 {%- endif %}
@@ -40,8 +42,6 @@
 {%- endif %}
 
 <link rel="stylesheet" href="{{ url_for(theme.css) }}/main.css">
-
-{{ next_pre() }}
 
 {{ next_font() }}
 

--- a/layout/_partials/head/head.njk
+++ b/layout/_partials/head/head.njk
@@ -41,6 +41,8 @@
 
 <link rel="stylesheet" href="{{ url_for(theme.css) }}/main.css">
 
+{{ next_pre() }}
+
 {{ next_font() }}
 
 <link rel="stylesheet" href="{{ theme.vendors.fontawesome }}">

--- a/scripts/helpers/engine.js
+++ b/scripts/helpers/engine.js
@@ -42,9 +42,9 @@ hexo.extend.helper.register('next_pre', function() {
   const h = enable ? links.host = host || 'https://fonts.googleapis.com' : '';
   const i = links[internal];
   const p = links[plugins];
-  const H = h === '' ? '' : `<link rel="preconnect" href="${h}" crossorigin>\n<link rel="dns-prefetch" href="${h}">`;
-  const I = i === '' ? '' : `<link rel="preconnect" href="${i}" crossorigin>\n<link rel="dns-prefetch" href="${i}">`;
-  const P = p === '' ? '' : `<link rel="preconnect" href="${p}" crossorigin>\n<link rel="dns-prefetch" href="${p}">`;
+  const H = h === '' ? '' : `<link rel="preconnect" href="${h}" crossorigin>\n`;
+  const I = i === '' ? '' : `<link rel="preconnect" href="${i}" crossorigin>\n`;
+  const P = p === '' ? '' : `<link rel="preconnect" href="${p}" crossorigin>\n`;
   return [...new Set([H, I, P])].join('\n');
 });
 

--- a/scripts/helpers/engine.js
+++ b/scripts/helpers/engine.js
@@ -39,7 +39,7 @@ hexo.extend.helper.register('next_pre', function() {
     unpkg   : 'https://unpkg.com',
     cdnjs   : 'https://cdnjs.cloudflare.com'
   };
-  const h = enable ? links.host = host || 'https://fonts.googleapis.com' : '';
+  const h = enable ? host || 'https://fonts.googleapis.com' : '';
   const i = links[internal];
   const p = links[plugins];
   const results = [...new Set([h, i, p].filter(x => x))].map(

--- a/scripts/helpers/engine.js
+++ b/scripts/helpers/engine.js
@@ -28,6 +28,29 @@ hexo.extend.helper.register('next_js', function(file, pjax = false) {
   return `<script ${pjax ? 'data-pjax ' : ''}src="${src}"></script>`;
 });
 
+hexo.extend.helper.register('next_pre', function() {
+  const { preconnect } = this.theme;
+  const pre= preconnect.enable;
+  const fallback = preconnect.fallback;
+  if (!pre) return '';
+  const { enable, host } = this.theme.font;
+  const { internal, plugins } = this.theme.vendors;
+  const links = {
+    local   : '',
+    jsdelivr: `https://cdn.jsdelivr.net`,
+    unpkg   : `https://unpkg.com`,
+    cdnjs   : `https://cdnjs.cloudflare.com`
+  };
+  const h = enable ? links.host = host || `https://fonts.googleapis.com` : '';
+  const i = links[internal];
+  const p = links[plugins];
+  const H = h == '' ? '' : `<link rel="preconnect" href="${h}" crossorigin>\n<link rel="dns-prefetch" href="${h}">`;
+  const I = i == '' ? '' : `<link rel="preconnect" href="${i}" crossorigin>\n<link rel="dns-prefetch" href="${i}">`;
+  const P = p == '' ? '' : `<link rel="preconnect" href="${p}" crossorigin>\n<link rel="dns-prefetch" href="${p}">`;
+  const result = [...new Set([H, I, P])].join('\n');
+  return fallback ? result : result.replace(/<link rel="dns-prefetch"(([\s\S])*?)>/g, '');
+});
+
 hexo.extend.helper.register('post_gallery', function(photos) {
   if (!photos || !photos.length) return '';
   const content = photos.map(photo => `

--- a/scripts/helpers/engine.js
+++ b/scripts/helpers/engine.js
@@ -30,9 +30,7 @@ hexo.extend.helper.register('next_js', function(file, pjax = false) {
 
 hexo.extend.helper.register('next_pre', function() {
   const { preconnect } = this.theme;
-  const pre = preconnect.enable;
-  const fallback = preconnect.fallback;
-  if (!pre) return '';
+  if (!preconnect) return '';
   const { enable, host } = this.theme.font;
   const { internal, plugins } = this.theme.vendors;
   const links = {
@@ -47,8 +45,7 @@ hexo.extend.helper.register('next_pre', function() {
   const H = h === '' ? '' : `<link rel="preconnect" href="${h}" crossorigin>\n<link rel="dns-prefetch" href="${h}">`;
   const I = i === '' ? '' : `<link rel="preconnect" href="${i}" crossorigin>\n<link rel="dns-prefetch" href="${i}">`;
   const P = p === '' ? '' : `<link rel="preconnect" href="${p}" crossorigin>\n<link rel="dns-prefetch" href="${p}">`;
-  const result = [...new Set([H, I, P])].join('\n');
-  return fallback ? result : result.replace(/<link rel="dns-prefetch"(([\s\S])*?)>/g, '');
+  return [...new Set([H, I, P])].join('\n');
 });
 
 hexo.extend.helper.register('post_gallery', function(photos) {

--- a/scripts/helpers/engine.js
+++ b/scripts/helpers/engine.js
@@ -37,11 +37,11 @@ hexo.extend.helper.register('next_pre', function() {
   const { internal, plugins } = this.theme.vendors;
   const links = {
     local   : '',
-    jsdelivr: `https://cdn.jsdelivr.net`,
-    unpkg   : `https://unpkg.com`,
-    cdnjs   : `https://cdnjs.cloudflare.com`
+    jsdelivr: 'https://cdn.jsdelivr.net',
+    unpkg   : 'https://unpkg.com',
+    cdnjs   : 'https://cdnjs.cloudflare.com'
   };
-  const h = enable ? links.host = host || `https://fonts.googleapis.com` : '';
+  const h = enable ? links.host = host || 'https://fonts.googleapis.com' : '';
   const i = links[internal];
   const p = links[plugins];
   const H = h === '' ? '' : `<link rel="preconnect" href="${h}" crossorigin>\n<link rel="dns-prefetch" href="${h}">`;

--- a/scripts/helpers/engine.js
+++ b/scripts/helpers/engine.js
@@ -42,10 +42,10 @@ hexo.extend.helper.register('next_pre', function() {
   const h = enable ? links.host = host || 'https://fonts.googleapis.com' : '';
   const i = links[internal];
   const p = links[plugins];
-  const H = h === '' ? '' : `<link rel="preconnect" href="${h}" crossorigin>\n`;
-  const I = i === '' ? '' : `<link rel="preconnect" href="${i}" crossorigin>\n`;
-  const P = p === '' ? '' : `<link rel="preconnect" href="${p}" crossorigin>\n`;
-  return [...new Set([H, I, P])].join('\n');
+  const H = h === '' ? '' : `<link rel="preconnect" href="${h}" crossorigin>`;
+  const I = i === '' ? '' : `<link rel="preconnect" href="${i}" crossorigin>`;
+  const P = p === '' ? '' : `<link rel="preconnect" href="${p}" crossorigin>`;
+  return [...new Set([H, I, P])].filter(e => e).join('\n');
 });
 
 hexo.extend.helper.register('post_gallery', function(photos) {

--- a/scripts/helpers/engine.js
+++ b/scripts/helpers/engine.js
@@ -42,10 +42,10 @@ hexo.extend.helper.register('next_pre', function() {
   const h = enable ? links.host = host || 'https://fonts.googleapis.com' : '';
   const i = links[internal];
   const p = links[plugins];
-  const H = h === '' ? '' : `<link rel="preconnect" href="${h}" crossorigin>`;
-  const I = i === '' ? '' : `<link rel="preconnect" href="${i}" crossorigin>`;
-  const P = p === '' ? '' : `<link rel="preconnect" href="${p}" crossorigin>`;
-  return [...new Set([H, I, P])].filter(e => e).join('\n');
+  const results = [...new Set([h, i, p].filter(x => x))].map(
+    x => `<link rel="preconnect" href="${x}" crossorigin>`
+  );
+  return results.join('\n');
 });
 
 hexo.extend.helper.register('post_gallery', function(photos) {

--- a/scripts/helpers/engine.js
+++ b/scripts/helpers/engine.js
@@ -30,7 +30,7 @@ hexo.extend.helper.register('next_js', function(file, pjax = false) {
 
 hexo.extend.helper.register('next_pre', function() {
   const { preconnect } = this.theme;
-  const pre= preconnect.enable;
+  const pre = preconnect.enable;
   const fallback = preconnect.fallback;
   if (!pre) return '';
   const { enable, host } = this.theme.font;
@@ -44,9 +44,9 @@ hexo.extend.helper.register('next_pre', function() {
   const h = enable ? links.host = host || `https://fonts.googleapis.com` : '';
   const i = links[internal];
   const p = links[plugins];
-  const H = h == '' ? '' : `<link rel="preconnect" href="${h}" crossorigin>\n<link rel="dns-prefetch" href="${h}">`;
-  const I = i == '' ? '' : `<link rel="preconnect" href="${i}" crossorigin>\n<link rel="dns-prefetch" href="${i}">`;
-  const P = p == '' ? '' : `<link rel="preconnect" href="${p}" crossorigin>\n<link rel="dns-prefetch" href="${p}">`;
+  const H = h === '' ? '' : `<link rel="preconnect" href="${h}" crossorigin>\n<link rel="dns-prefetch" href="${h}">`;
+  const I = i === '' ? '' : `<link rel="preconnect" href="${i}" crossorigin>\n<link rel="dns-prefetch" href="${i}">`;
+  const P = p === '' ? '' : `<link rel="preconnect" href="${p}" crossorigin>\n<link rel="dns-prefetch" href="${p}">`;
   const result = [...new Set([H, I, P])].join('\n');
   return fallback ? result : result.replace(/<link rel="dns-prefetch"(([\s\S])*?)>/g, '');
 });

--- a/scripts/helpers/engine.js
+++ b/scripts/helpers/engine.js
@@ -42,8 +42,8 @@ hexo.extend.helper.register('next_pre', function() {
   const h = enable ? host || 'https://fonts.googleapis.com' : '';
   const i = links[internal];
   const p = links[plugins];
-  const results = [...new Set([h, i, p].filter(x => x))].map(
-    x => `<link rel="preconnect" href="${x}" crossorigin>`
+  const results = [...new Set([h, i, p].filter(origin => origin))].map(
+    origin => `<link rel="preconnect" href="${origin}" crossorigin>`
   );
   return results.join('\n');
 });


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Nothing.

## What is the new behavior?
<!-- Description about this pull, in several words -->

- Link to demo site with this changes:
- Screenshots with this changes:
![屏幕截图 2020-10-07 224637](https://user-images.githubusercontent.com/29083921/95347254-47382580-08ef-11eb-8695-36b21196e68b.jpg)
![屏幕截图 2020-10-07 224839](https://user-images.githubusercontent.com/29083921/95347263-4a331600-08ef-11eb-8154-c302f024fbd6.jpg)

### How to use?

In NexT `_config.yml`:
```yml
# Preconnect CDN for fonts and vendors.
# For more information: https://www.w3.org/TR/resource-hints/#preconnect
preconnect: true
```
