### PR TITLE
Use window size to determine sidebar display, and unify behaviour for margin and dimmer

### DIFF
--- a/source/css/_common/outline/sidebar/sidebar-dimmer.styl
+++ b/source/css/_common/outline/sidebar/sidebar-dimmer.styl
@@ -2,7 +2,7 @@
   display: none;
 }
 
-+mobile() {
++tablet-mobile() {
   .sidebar-dimmer {
     background: black;
     display: block;

--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -319,7 +319,7 @@ NexT.utils = {
 
   updateSidebarPosition: function() {
     NexT.utils.initSidebarDimension();
-    if (window.screen.width < 992 || CONFIG.scheme === 'Pisces' || CONFIG.scheme === 'Gemini') return;
+    if (window.innerWidth < 992 || CONFIG.scheme === 'Pisces' || CONFIG.scheme === 'Gemini') return;
     // Expand sidebar on post detail page by default, when post has a toc.
     const hasTOC = document.querySelector('.post-toc');
     let display = CONFIG.page.sidebar;


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [ ] Tests for the changes was made (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [ ] Pisces | Gemini have been tested.
- N/A [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

1. Screen size is used to determine whether sidebar is shown on page load, instead of window size.
  This means those who have a narrow window on a wide screen will still have the sidebar shown.
  This covers page content.

2. On "tablet" view (between "desktop" and "mobile"), the page content will be covered by the sidebar (`-margin`), but it is not dimmed (`-dimmer`).
    ![-margin -dimmer](https://user-images.githubusercontent.com/299873/96817036-7a4cdf80-13ec-11eb-9495-3442a46ec1e4.png)

    Compare:
    - "desktop" view (`+margin -dimmer`): ![+margin -dimmer](https://user-images.githubusercontent.com/299873/96817336-1d055e00-13ed-11eb-88c6-87907c8adc7b.png)

    - "mobile" view (`-margin +dimmer`): ![-margin +dimmer](https://user-images.githubusercontent.com/299873/96817065-8638a180-13ec-11eb-8cd4-ee1c734b3452.png)


Issue resolved: N/A

## What is the new behavior?
<!-- Description about this pull, in several words -->
1. Window size is used to determine whether to show sidebar on page load.
2. `-margin` will always go with `+dimmer`. On "tablet" view, it will display as `-margin +dimmer` (same as "mobile" view).

- Link to demo site with this changes: N/A
- Screenshots with this changes: See above

### How to use?

N/A
