### PR TITLE
Feat: Adds an optional "copyright" in a post's front-matter which allows a user to change whether to show CC License notices under a post

### DIFF
--- a/layout/_macro/post.njk
+++ b/layout/_macro/post.njk
@@ -107,7 +107,7 @@
           {{ partial('_partials/post/post-reward.njk') }}
         {%- endif %}
 
-        {%- if theme.creative_commons.license and theme.creative_commons.post and not post.copyright %}
+        {%- if theme.creative_commons.license and theme.creative_commons.post and post.copyright != false %}
           {{ partial('_partials/post/post-copyright.njk') }}
         {%- endif %}
 

--- a/layout/_macro/post.njk
+++ b/layout/_macro/post.njk
@@ -107,7 +107,7 @@
           {{ partial('_partials/post/post-reward.njk') }}
         {%- endif %}
 
-        {%- if theme.creative_commons.license and theme.creative_commons.post and post.copyright != false %}
+        {%- if theme.creative_commons.license and theme.creative_commons.post and post.copyright !== false %}
           {{ partial('_partials/post/post-copyright.njk') }}
         {%- endif %}
 

--- a/layout/_macro/post.njk
+++ b/layout/_macro/post.njk
@@ -107,7 +107,7 @@
           {{ partial('_partials/post/post-reward.njk') }}
         {%- endif %}
 
-        {%- if theme.creative_commons.license and theme.creative_commons.post %}
+        {%- if theme.creative_commons.license and theme.creative_commons.post and not post.copyright %}
           {{ partial('_partials/post/post-copyright.njk') }}
         {%- endif %}
 


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [x] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

When `theme.creative_commons.post` is set to `true`, all posts of a site shows the CC copyright notice.

## What is the new behavior?
<!-- Description about this pull, in several words -->

When `theme.creative_commons.post` is set to `true`, the user may still decide whether a post shows these copyright information using the article front-matter. The copyright notice will still appear if the article front-matter does not include the `copyright` setting.

### How to use?

In NexT `_config.yml`:  
```yml
---
copyright: false # disable copyright info (post follows xxx license, etc.) of a single post
```
