### PR TITLE
Feat add hyperlink support to group-pictures

### DIFF
--- a/scripts/tags/group-pictures.js
+++ b/scripts/tags/group-pictures.js
@@ -126,7 +126,7 @@ module.exports = ctx => function(args, content) {
 
   content = ctx.render.renderSync({ text: content, engine: 'markdown' });
 
-  const pictures = content.match(/<img[\s\S]*?>/g);
+  const pictures = content.match(/(<a[^>]*>((?!<\/a)(.|\n))+<\/a>)|(<img[^>]+>)/g);
 
   return `<div class="group-picture">${templates.dispatch(pictures, group, layout)}</div>`;
 };

--- a/test/tags/group-pictures.js
+++ b/test/tags/group-pictures.js
@@ -35,11 +35,11 @@ Text
   });
 
   it('set hyperlinks', () => {
-    groupPicture(['4-1'], `
+    groupPicture(['4-3'], `
 ![](/images/sample.png)
 [![](/images/sample.png)](https://theme-next.js.org/)
 [![](/images/sample.png)](https://theme-next.js.org/)
-![](/images/sample.png)`).should.eql('<div class="group-picture"><div class="group-picture-row"><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><a href="https://theme-next.js.org/"><img src="/images/sample.png"></a></div><div class="group-picture-column"><a href="https://theme-next.js.org/"><img src="/images/sample.png"></a></div><div class="group-picture-column"><img src="/images/sample.png"></div></div></div>');
+![](/images/sample.png)`).should.eql('<div class="group-picture"><div class="group-picture-row"><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><a href="https://theme-next.js.org/"><img src="/images/sample.png"></a></div></div><div class="group-picture-row"><div class="group-picture-column"><a href="https://theme-next.js.org/"><img src="/images/sample.png"></a></div><div class="group-picture-column"><img src="/images/sample.png"></div></div></div>');
   });
 
   it('no layout', () => {

--- a/test/tags/group-pictures.js
+++ b/test/tags/group-pictures.js
@@ -33,6 +33,14 @@ Text
 Text
 ![](/images/sample.png)`).should.eql('<div class="group-picture"><div class="group-picture-row"><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><img src="/images/sample.png"></div></div></div>');
   });
+  
+  it('set hyperlinks', () => {
+    groupPicture(['4-1'], `
+![](/images/sample.png)
+[![](/images/sample.png)](https://theme-next.js.org/)
+[![](/images/sample.png)](https://theme-next.js.org/)
+![](/images/sample.png)`).should.eql('<div class="group-picture"><div class="group-picture-row"><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><img src="/images/sample.png"></div></div></div>');
+  });
 
   it('no layout', () => {
     groupPicture(['NaN-NaN'], `

--- a/test/tags/group-pictures.js
+++ b/test/tags/group-pictures.js
@@ -33,7 +33,7 @@ Text
 Text
 ![](/images/sample.png)`).should.eql('<div class="group-picture"><div class="group-picture-row"><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><img src="/images/sample.png"></div></div></div>');
   });
-  
+
   it('set hyperlinks', () => {
     groupPicture(['4-1'], `
 ![](/images/sample.png)

--- a/test/tags/group-pictures.js
+++ b/test/tags/group-pictures.js
@@ -39,7 +39,7 @@ Text
 ![](/images/sample.png)
 [![](/images/sample.png)](https://theme-next.js.org/)
 [![](/images/sample.png)](https://theme-next.js.org/)
-![](/images/sample.png)`).should.eql('<div class="group-picture"><div class="group-picture-row"><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><a href="https://theme-next.js.org/"><img src="/images/sample.png"></a></div><a href="https://theme-next.js.org/"><div class="group-picture-column"><img src="/images/sample.png"></a><img src="/images/sample.png"></div></div></div>');
+![](/images/sample.png)`).should.eql('<div class="group-picture"><div class="group-picture-row"><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><a href="https://theme-next.js.org/"><img src="/images/sample.png"></a></div><div class="group-picture-column"><a href="https://theme-next.js.org/"><img src="/images/sample.png"></a></div><div class="group-picture-column"><img src="/images/sample.png"></div></div></div>');
   });
 
   it('no layout', () => {

--- a/test/tags/group-pictures.js
+++ b/test/tags/group-pictures.js
@@ -39,7 +39,7 @@ Text
 ![](/images/sample.png)
 [![](/images/sample.png)](https://theme-next.js.org/)
 [![](/images/sample.png)](https://theme-next.js.org/)
-![](/images/sample.png)`).should.eql('<div class="group-picture"><div class="group-picture-row"><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><img src="/images/sample.png"></div></div></div>');
+![](/images/sample.png)`).should.eql('<div class="group-picture"><div class="group-picture-row"><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><a href="https://theme-next.js.org/"><img src="/images/sample.png"></a></div><a href="https://theme-next.js.org/"><div class="group-picture-column"><img src="/images/sample.png"></a><img src="/images/sample.png"></div></div></div>');
   });
 
   it('no layout', () => {

--- a/test/tags/group-pictures.js
+++ b/test/tags/group-pictures.js
@@ -42,6 +42,13 @@ Text
 ![](/images/sample.png)`).should.eql('<div class="group-picture"><div class="group-picture-row"><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><a href="https://theme-next.js.org/"><img src="/images/sample.png"></a></div></div><div class="group-picture-row"><div class="group-picture-column"><a href="https://theme-next.js.org/"><img src="/images/sample.png"></a></div><div class="group-picture-column"><img src="/images/sample.png"></div></div></div>');
   });
 
+  it('set hyperlinks 2', () => {
+    groupPicture(['3-1'], `
+![](/images/sample.png)
+[![](/images/sample.png)](https://theme-next.js.org/)
+![](/images/sample.png)`).should.eql('<div class="group-picture"><div class="group-picture-row"><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><a href="https://theme-next.js.org/"><img src="/images/sample.png"></a></div><div class="group-picture-column"><img src="/images/sample.png"></div></div></div>');
+  });
+
   it('no layout', () => {
     groupPicture(['NaN-NaN'], `
 ![](/images/sample.png)

--- a/test/tags/group-pictures.js
+++ b/test/tags/group-pictures.js
@@ -4,6 +4,9 @@ require('chai').should();
 const Hexo = require('hexo');
 const hexo = new Hexo();
 
+const link = '<div class="group-picture-column"><a href="https://theme-next.js.org/"><img src="/images/sample.png"></a></div>';
+const image = '<div class="group-picture-column"><img src="/images/sample.png"></div>';
+
 describe('group-pictures', () => {
   const groupPicture = require('../../scripts/tags/group-pictures')(hexo);
 
@@ -13,7 +16,7 @@ describe('group-pictures', () => {
     groupPicture(['3-1'], `
 ![](/images/sample.png)
 ![](/images/sample.png)
-![](/images/sample.png)`).should.eql('<div class="group-picture"><div class="group-picture-row"><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><img src="/images/sample.png"></div></div></div>');
+![](/images/sample.png)`).should.eql(`<div class="group-picture"><div class="group-picture-row">${image}${image}${image}</div></div>`);
   });
 
   it('layout 5-2', () => {
@@ -22,7 +25,7 @@ describe('group-pictures', () => {
 ![](/images/sample.png)
 ![](/images/sample.png)
 ![](/images/sample.png)
-![](/images/sample.png)`).should.eql('<div class="group-picture"><div class="group-picture-row"><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><img src="/images/sample.png"></div></div><div class="group-picture-row"><div class="group-picture-column"><img src="/images/sample.png"></div></div><div class="group-picture-row"><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><img src="/images/sample.png"></div></div></div>');
+![](/images/sample.png)`).should.eql(`<div class="group-picture"><div class="group-picture-row">${image}${image}</div><div class="group-picture-row">${image}</div><div class="group-picture-row">${image}${image}</div></div>`);
   });
 
   it('remove text', () => {
@@ -31,7 +34,7 @@ describe('group-pictures', () => {
 Text
 ![](/images/sample.png)
 Text
-![](/images/sample.png)`).should.eql('<div class="group-picture"><div class="group-picture-row"><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><img src="/images/sample.png"></div></div></div>');
+![](/images/sample.png)`).should.eql(`<div class="group-picture"><div class="group-picture-row">${image}${image}${image}</div></div>`);
   });
 
   it('set hyperlinks', () => {
@@ -39,14 +42,14 @@ Text
 ![](/images/sample.png)
 [![](/images/sample.png)](https://theme-next.js.org/)
 [![](/images/sample.png)](https://theme-next.js.org/)
-![](/images/sample.png)`).should.eql('<div class="group-picture"><div class="group-picture-row"><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><a href="https://theme-next.js.org/"><img src="/images/sample.png"></a></div></div><div class="group-picture-row"><div class="group-picture-column"><a href="https://theme-next.js.org/"><img src="/images/sample.png"></a></div><div class="group-picture-column"><img src="/images/sample.png"></div></div></div>');
+![](/images/sample.png)`).should.eql(`<div class="group-picture"><div class="group-picture-row">${image}${link}</div><div class="group-picture-row">${link}${image}</div></div>`);
   });
 
   it('set hyperlinks 2', () => {
     groupPicture(['3-1'], `
 ![](/images/sample.png)
 [![](/images/sample.png)](https://theme-next.js.org/)
-![](/images/sample.png)`).should.eql('<div class="group-picture"><div class="group-picture-row"><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><a href="https://theme-next.js.org/"><img src="/images/sample.png"></a></div><div class="group-picture-column"><img src="/images/sample.png"></div></div></div>');
+![](/images/sample.png)`).should.eql(`<div class="group-picture"><div class="group-picture-row">${image}${link}${image}</div></div>`);
   });
 
   it('no layout', () => {
@@ -55,6 +58,6 @@ Text
 ![](/images/sample.png)
 ![](/images/sample.png)
 ![](/images/sample.png)
-![](/images/sample.png)`).should.eql('<div class="group-picture"><div class="group-picture-row"><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><img src="/images/sample.png"></div></div><div class="group-picture-row"><div class="group-picture-column"><img src="/images/sample.png"></div><div class="group-picture-column"><img src="/images/sample.png"></div></div></div>');
+![](/images/sample.png)`).should.eql(`<div class="group-picture"><div class="group-picture-row">${image}${image}${image}</div><div class="group-picture-row">${image}${image}</div></div>`);
   });
 });


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

The ```<a>``` tag outside the picture tag disappears after using pictures hyperlink tags in Group Pictures, and the pictures have no hyperlinks.

## What is the new behavior?
<!-- Description about this pull, in several words -->
The hyperlink of the pictures in Group Pictures can be clicked and the target can be followed.

- Link to demo site with this changes: https://no5972.tk/cms/about/#Special-Thanks
- Screenshots with this changes:

### How to use?

In posts' markdown:
```md
{% gp 3-5 %}
  [![](/images/docs/next.svg)](https://theme-next.js.org/)
  ![](/images/docs/next.svg)
  [![](/images/docs/next.svg)](https://theme-next.js.org/)
{% endgp %}

{% grouppicture 3-5 %}
  [![](/images/docs/next.svg)](https://theme-next.js.org/)
  ![](/images/docs/next.svg)
  [![](/images/docs/next.svg)](https://theme-next.js.org/)
{% endgrouppicture %}
```
