### PR TITLE
[Feature] add Waline comment system support

### DIFF
--- a/layout/_partials/post/post-meta.njk
+++ b/layout/_partials/post/post-meta.njk
@@ -51,7 +51,7 @@
   {%- endif %}
 
   {# LeanCloud PageView #}
-  {%- if theme.leancloud_visitors.enable or (theme.valine and theme.valine.enable and theme.valine.visitor) %}
+  {%- if theme.leancloud_visitors.enable or (theme.valine and theme.valine.enable and theme.valine.visitor) or (theme.waline and theme.waline.enable and theme.waline.visitor) %}
     <span id="{{ url_for(post.path) }}" class="post-meta-item leancloud_visitors" data-flag-title="{{ post.title }}" title="{{ __('post.views') }}">
       <span class="post-meta-item-icon">
         <i class="far fa-eye"></i>

--- a/layout/_third-party/comments/waline.njk
+++ b/layout/_third-party/comments/waline.njk
@@ -1,0 +1,10 @@
+<script>
+NexT.utils.loadComments('#waline-comments', () => {
+  NexT.utils.getScript('{{ theme.vendors.waline }}', () => {
+    new Waline(Object.assign({{ theme.waline | safedump }}, {
+      el: '#waline-comments',
+      path: {{ url_for(page.path) | replace(r/index\.html$/, '') | safedump }}
+    }));
+  }, window.Waline);
+});
+</script>

--- a/scripts/events/lib/config.js
+++ b/scripts/events/lib/config.js
@@ -31,7 +31,7 @@ module.exports = hexo => {
       warning('waline.visitor', 'leancloud_visitors');
       leancloud_visitors.enable = false;
     }
-  }  
+  }
   hexo.config.meta_generator = false;
 
   // Custom languages support. Introduced in NexT v6.3.0.

--- a/scripts/events/lib/config.js
+++ b/scripts/events/lib/config.js
@@ -10,7 +10,7 @@ module.exports = hexo => {
     hexo.log.warn('Documentation: https://theme-next.js.org/docs/getting-started/configuration.html');
   }
 
-  const { cache, language_switcher, leancloud_visitors, valine } = hexo.theme.config;
+  const { cache, language_switcher, leancloud_visitors, valine, waline } = hexo.theme.config;
   const warning = function(...args) {
     hexo.log.warn(`Since ${args[0]} is turned on, the ${args[1]} is disabled to avoid potential hazards.`);
   };
@@ -23,10 +23,15 @@ module.exports = hexo => {
     warning('caching', '`relative_link` option in Hexo `_config.yml`');
     hexo.config.relative_link = false;
   }
-  if (leancloud_visitors && leancloud_visitors.enable && valine && valine.enable && valine.visitor) {
-    warning('valine.visitor', 'leancloud_visitors');
-    leancloud_visitors.enable = false;
-  }
+  if (leancloud_visitors && leancloud_visitors.enable) {
+    if (valine && valine.enable && valine.visitor) {
+      warning('valine.visitor', 'leancloud_visitors');
+      leancloud_visitors.enable = false;
+    } else if (waline && waline.enable && waline.visitor) {
+      warning('waline.visitor', 'leancloud_visitors');
+      leancloud_visitors.enable = false;
+    }
+  }  
   hexo.config.meta_generator = false;
 
   // Custom languages support. Introduced in NexT v6.3.0.

--- a/scripts/filters/comment/waline.js
+++ b/scripts/filters/comment/waline.js
@@ -1,0 +1,35 @@
+/* global hexo */
+
+'use strict';
+
+const path = require('path');
+const { iconText } = require('./common');
+
+// Add comment
+hexo.extend.filter.register('theme_inject', injects => {
+  let theme = hexo.theme.config;
+  if (!theme.waline.enable || !theme.waline.serverURL) return;
+
+  injects.comment.raw('waline', '<div class="comments" id="waline-comments"></div>', {}, {cache: true});
+
+  injects.bodyEnd.file('waline', path.join(hexo.theme_dir, 'layout/_third-party/comments/waline.swig'));
+
+});
+
+// Add post_meta
+hexo.extend.filter.register('theme_inject', injects => {
+  let theme = hexo.theme.config;
+  if (!theme.waline.enable || !theme.waline.serverURL) return;
+
+  injects.postMeta.raw('waline', `
+  {% if post.comments and (is_post() or theme.waline.comment_count) %}
+  <span class="post-meta-item">
+    ${iconText('far fa-comment', 'waline')}
+    <a title="waline" href="{{ url_for(post.path) }}#waline-comments" itemprop="discussionUrl">
+      <span class="post-comments-count waline-comment-count" id="{{ url_for(post.path) }}" data-xid="{{ url_for(post.path) }}" itemprop="commentCount"></span>
+    </a>
+  </span>
+  {% endif %}
+  `, {}, {}, theme.waline.post_meta_order);
+
+});

--- a/scripts/filters/comment/waline.js
+++ b/scripts/filters/comment/waline.js
@@ -18,7 +18,7 @@ hexo.extend.filter.register('theme_inject', injects => {
 
 // Add post_meta
 hexo.extend.filter.register('theme_inject', injects => {
-  let theme = hexo.theme.config;
+  const theme = hexo.theme.config;
   if (!theme.waline.enable || !theme.waline.serverURL) return;
 
   injects.postMeta.raw('waline', `

--- a/scripts/filters/comment/waline.js
+++ b/scripts/filters/comment/waline.js
@@ -7,7 +7,7 @@ const { iconText } = require('./common');
 
 // Add comment
 hexo.extend.filter.register('theme_inject', injects => {
-  let theme = hexo.theme.config;
+  const theme = hexo.theme.config;
   if (!theme.waline.enable || !theme.waline.serverURL) return;
 
   injects.comment.raw('waline', '<div class="comments" id="waline-comments"></div>', {}, {cache: true});

--- a/scripts/filters/comment/waline.js
+++ b/scripts/filters/comment/waline.js
@@ -8,7 +8,7 @@ const { iconText } = require('./common');
 // Add comment
 hexo.extend.filter.register('theme_inject', injects => {
   const theme = hexo.theme.config;
-  if (!theme.waline.enable || !theme.waline.serverURL) return;
+  if (!theme.waline || !theme.waline.enable || !theme.waline.serverURL) return;
 
   injects.comment.raw('waline', '<div class="comments" id="waline-comments"></div>', {}, {cache: true});
 
@@ -19,7 +19,7 @@ hexo.extend.filter.register('theme_inject', injects => {
 // Add post_meta
 hexo.extend.filter.register('theme_inject', injects => {
   const theme = hexo.theme.config;
-  if (!theme.waline.enable || !theme.waline.serverURL) return;
+  if (!theme.waline || !theme.waline.enable || !theme.waline.serverURL) return;
 
   injects.postMeta.raw('waline', `
   {% if post.comments and (is_post() or theme.waline.comment_count) %}


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [ ] Tests for the changes was maked (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [ ] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue resolved: N/A

## What is the new behavior?
<!-- Description about this pull, in several words -->

- Link to demo site with this changes:
- Screenshots with this changes:

### How to use?

In NexT `_config.yml`:
```yml
# Waline. 
# You need deploy waline server in vercel then you can get serverURL
# more info please open https://waline.js.org
valine:
  enable: true
  serverURL: # Your waline server URL
```
