### PR TITLE
Bump peaceiris/actions-label-commenter to 1.9.0

### DIFF
--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -13,7 +13,4 @@ jobs:
         with:
           ref: master
       - name: Label Commenter
-        # Exclude https://github.com/peaceiris/actions-label-commenter/pull/316
-        uses: peaceiris/actions-label-commenter@v1.7.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+        uses: peaceiris/actions-label-commenter@v1.9.0


### PR DESCRIPTION
[Release actions-label-commenter v1.9.0 · peaceiris/actions-label-commenter](https://github.com/peaceiris/actions-label-commenter/releases/tag/v1.9.0)
