### PR TITLE
Use correct language codes in multi-language sites

### DIFF
--- a/layout/_layout.njk
+++ b/layout/_layout.njk
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ config.language }}">
+<html lang="{{ page.lang }}">
 <head>
   {{ partial('_partials/head/head.njk', {}, {cache: theme.cache.enable}) }}
   {%- include '_partials/head/head-unique.njk' -%}

--- a/layout/_macro/post.njk
+++ b/layout/_macro/post.njk
@@ -5,7 +5,7 @@
   {# Gallery support #}
   {{ post_gallery(post.photos) }}
 
-  <article itemscope itemtype="http://schema.org/Article" class="post-content" lang="{{ post.lang or config.language }}">
+  <article itemscope itemtype="http://schema.org/Article" class="post-content" lang="{{ post.lang }}">
     <link itemprop="mainEntityOfPage" href="{{ post.permalink }}">
 
     <span hidden itemprop="author" itemscope itemtype="http://schema.org/Person">

--- a/layout/page.njk
+++ b/layout/page.njk
@@ -22,7 +22,7 @@
     {##################}
     {### PAGE BLOCK ###}
     {##################}
-    <div class="post-block" lang="{{ page.lang or config.language }}">
+    <div class="post-block" lang="{{ page.lang }}">
       {%- include '_partials/page/page-header.njk' -%}
       {#################}
       {### PAGE BODY ###}


### PR DESCRIPTION
In a multi-language site, language codes are different in different pages. We should use `page.lang` for language codes, instead of `config.language`.

<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue resolved:

## What is the new behavior?
<!-- Description about this pull, in several words -->

- Link to demo site with this changes: https://jinzhe-blog-o0kv8jx5d.vercel.app/
- Screenshots with this changes:
English page:
![image](https://user-images.githubusercontent.com/9496702/103459460-9ff44000-4cdd-11eb-8f64-d9f18c241f15.png)
Chinese page:
![image](https://user-images.githubusercontent.com/9496702/103459470-b6020080-4cdd-11eb-91b3-966878bfbe34.png)

### How to use?

In NexT `_config.yml`:
```yml

```
