### PR TITLE
Explicitly use HTTPS for Vendors

### DIFF
--- a/scripts/events/lib/vendors.js
+++ b/scripts/events/lib/vendors.js
@@ -25,9 +25,9 @@ module.exports = hexo => {
     const { name, version, file, alias, unavailable } = value;
     const links = {
       local   : url_for.call(hexo, `lib/${name}/${file}`),
-      jsdelivr: `//cdn.jsdelivr.net/npm/${name}@${version}/${file}`,
-      unpkg   : `//unpkg.com/${name}@${version}/${file}`,
-      cdnjs   : `//cdnjs.cloudflare.com/ajax/libs/${alias || name}/${version}/${file.replace(/^(dist|lib|)\/(browser\/|)/, '')}`
+      jsdelivr: `https://cdn.jsdelivr.net/npm/${name}@${version}/${file}`,
+      unpkg   : `https://unpkg.com/${name}@${version}/${file}`,
+      cdnjs   : `https://cdnjs.cloudflare.com/ajax/libs/${alias || name}/${version}/${file.replace(/^(dist|lib|)\/(browser\/|)/, '')}`
     };
     let { plugins = 'jsdelivr' } = vendors;
     if (plugins === 'cdnjs' && unavailable && unavailable.includes('cdnjs')) plugins = 'jsdelivr';

--- a/scripts/helpers/engine.js
+++ b/scripts/helpers/engine.js
@@ -20,9 +20,9 @@ hexo.extend.helper.register('next_js', function(file, pjax = false) {
   const { internal } = this.theme.vendors;
   const links = {
     local   : this.url_for(`${this.theme.js}/${file}`),
-    jsdelivr: `//cdn.jsdelivr.net/npm/hexo-theme-next@${next_version}/source/js/${file}`,
-    unpkg   : `//unpkg.com/hexo-theme-next@${next_version}/source/js/${file}`,
-    cdnjs   : `//cdnjs.cloudflare.com/ajax/libs/hexo-theme-next/${next_version}/${file}`
+    jsdelivr: `https://cdn.jsdelivr.net/npm/hexo-theme-next@${next_version}/source/js/${file}`,
+    unpkg   : `https://unpkg.com/hexo-theme-next@${next_version}/source/js/${file}`,
+    cdnjs   : `https://cdnjs.cloudflare.com/ajax/libs/hexo-theme-next/${next_version}/${file}`
   };
   const src = links[internal] || links.local;
   return `<script ${pjax ? 'data-pjax ' : ''}src="${src}"></script>`;

--- a/scripts/helpers/font.js
+++ b/scripts/helpers/font.js
@@ -7,7 +7,7 @@ module.exports = function() {
   if (!config || !config.enable) return '';
 
   const fontStyles = ':300,300italic,400,400italic,700,700italic';
-  const fontHost = config.host || '//fonts.googleapis.com';
+  const fontHost = config.host || 'https://fonts.googleapis.com';
 
   // Get a font list from config
   let fontFamilies = [];

--- a/test/helpers/font.js
+++ b/test/helpers/font.js
@@ -5,7 +5,7 @@ const Hexo = require('hexo');
 const hexo = new Hexo();
 
 const fontStyles = ':300,300italic,400,400italic,700,700italic';
-const fontHost = '//fonts.googleapis.com';
+const fontHost = 'https://fonts.googleapis.com';
 
 describe('font', () => {
   const nextFont = require('../../scripts/helpers/font').bind(hexo);


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [x] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [x] **Other: Explicitly use HTTPS to load third-party plugins and fonts from CDN vendors**

## Change: explicitly use HTTPS for Vendors
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Currently, Jsdelivr(default) and unpkg.com has deployed HSTS, but we use a compromise solution to let the browser determine which HTTP(S) protocol to use.

```html
<!-- Before -->
<script src="//cdn.jsdelivr.net/npm/@next-theme/pjax@0.4.0/pjax.min.js"></script>
<!-- After change -->
<script src="https://cdn.jsdelivr.net/npm/@next-theme/pjax@0.4.0/pjax.min.js"></script>
```

If yours website continues to use HTTP, the browser will get a 301 or 307 redirect when requesting assets.

Neither CDNJS nor Google Fonts require it, but it is a wise choice to always use HTTPS.


