### PR TITLE
Add external link icon options

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -461,6 +461,8 @@ index_with_subtitle: false
 
 # Automatically add external URL with Base64 encrypt & decrypt.
 exturl: false
+# If true, an icon will be attached to each external URL
+exturlIcon: true
 
 # Google Webmaster tools verification.
 # See: https://developers.google.com/search

--- a/_config.yml
+++ b/_config.yml
@@ -462,7 +462,7 @@ index_with_subtitle: false
 # Automatically add external URL with Base64 encrypt & decrypt.
 exturl: false
 # If true, an icon will be attached to each external URL
-exturlIcon: true
+exturl_icon: true
 
 # Google Webmaster tools verification.
 # See: https://developers.google.com/search

--- a/scripts/filters/post.js
+++ b/scripts/filters/post.js
@@ -14,7 +14,7 @@ hexo.extend.filter.register('after_post_render', data => {
   if (theme.exturl) {
     const siteHost = parse(config.url).hostname || config.url;
     // External URL icon
-    const exturlIcon = theme.exturlIcon ? '<i class="fa fa-external-link-alt"></i>' : '';
+    const exturlIcon = theme.exturl_icon ? '<i class="fa fa-external-link-alt"></i>' : '';
     data.content = data.content.replace(/<a[^>]* href="([^"]+)"[^>]*>([^<]+)<\/a>/img, (match, href, html) => {
       // Exit if the href attribute doesn't exists.
       if (!href) return match;

--- a/scripts/filters/post.js
+++ b/scripts/filters/post.js
@@ -13,6 +13,8 @@ hexo.extend.filter.register('after_post_render', data => {
   }
   if (theme.exturl) {
     const siteHost = parse(config.url).hostname || config.url;
+    // External URL icon
+    const exturlIcon = theme.exturlIcon ? '<i class="fa fa-external-link-alt"></i>' : '';
     data.content = data.content.replace(/<a[^>]* href="([^"]+)"[^>]*>([^<]+)<\/a>/img, (match, href, html) => {
       // Exit if the href attribute doesn't exists.
       if (!href) return match;
@@ -21,7 +23,7 @@ hexo.extend.filter.register('after_post_render', data => {
       const link = parse(href);
       if (!link.protocol || link.hostname === siteHost) return match;
 
-      return `<span class="exturl" data-url="${Buffer.from(href).toString('base64')}">${html}<i class="fa fa-external-link-alt"></i></span>`;
+      return `<span class="exturl" data-url="${Buffer.from(href).toString('base64')}">${html}${exturlIcon}</span>`;
     });
   }
 


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue resolved: #177 

## What is the new behavior?
<!-- Description about this pull, in several words -->

- Link to demo site with this changes:
- Screenshots with this changes:

---

|  `exturl_icon: true`   | `exturl_icon: false`  |
|  ----  | ----  |
| ![QQ截图20210131213243](https://user-images.githubusercontent.com/76462613/106385584-0028ef80-640c-11eb-8ff8-149f478b1db1.png)  | ![QQ截图20210131213316](https://user-images.githubusercontent.com/76462613/106385588-04eda380-640c-11eb-8172-653c97b8260b.png) |




### How to use?

In NexT `_config.yml`:
```yml
# If true, an icon will be attached to each external URL
exturl_icon: true
```
