### PR TITLE
New reversed reading progess bar option

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -377,6 +377,8 @@ back2top:
 # Reading progress bar
 reading_progress:
   enable: false
+  # Available values: left | right
+  startAt: left
   # Available values: top | bottom
   position: top
   reversed: false

--- a/_config.yml
+++ b/_config.yml
@@ -379,6 +379,7 @@ reading_progress:
   enable: false
   # Available values: top | bottom
   position: top
+  reversed: false
   color: "#37c6c0"
   height: 3px
 

--- a/source/css/_common/components/reading-progress.styl
+++ b/source/css/_common/components/reading-progress.styl
@@ -2,7 +2,6 @@
   --progress: 0;
   background: unquote(hexo-config('reading_progress.color'));
   height: unquote(hexo-config('reading_progress.height'));
-  left: 0;
   position: fixed;
   z-index: $zindex-5;
 
@@ -10,6 +9,12 @@
     width: calc(100% - var(--progress));
   } else {
     width: var(--progress);
+  }
+
+  if (hexo-config('reading_progress.startAt') == 'right') {
+    right: 0;
+  } else {
+    left: 0;
   }
 
   if (hexo-config('reading_progress.position') == 'bottom') {

--- a/source/css/_common/components/reading-progress.styl
+++ b/source/css/_common/components/reading-progress.styl
@@ -1,10 +1,16 @@
 .reading-progress-bar {
+  --progress: 0;
   background: unquote(hexo-config('reading_progress.color'));
   height: unquote(hexo-config('reading_progress.height'));
   left: 0;
   position: fixed;
-  width: 0;
   z-index: $zindex-5;
+
+  if (hexo-config('reading_progress.reversed')) {
+    width: calc(100% - var(--progress));
+  } else {
+    width: var(--progress);
+  }
 
   if (hexo-config('reading_progress.position') == 'bottom') {
     bottom: 0;

--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -161,7 +161,7 @@ NexT.utils = {
           backToTop.querySelector('span').innerText = Math.round(scrollPercent) + '%';
         }
         if (readingProgressBar) {
-          readingProgressBar.style.width = scrollPercent.toFixed(2) + '%';
+          readingProgressBar.style.setProperty('--progress', scrollPercent.toFixed(2) + '%');
         }
       }
       if (!Array.isArray(NexT.utils.sections)) return;


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->
Currently, the width of the reading progress bar grows as the page **scrolls down**.

Issue resolved: https://github.com/next-theme/hexo-theme-next/discussions/218

## What is the new behavior?
<!-- Description about this pull, in several words -->
The width of the reading progress bar will grow as the page **scrolls up** if `reading_progress.reversed` is `true`.
A new CSS variable `--progress` is used to achieve this.

- Link to demo site with this changes: [sliphua.work](https://sliphua.work)
- Screenshots with this changes:

### How to use?

In NexT `_config.yml`:
```yml
reading_progress:
  reversed: false
```
