### PR TITLE
Use CSS transitions to animate `site-nav`

### DIFF
--- a/source/css/_common/outline/header/site-nav.styl
+++ b/source/css/_common/outline/header/site-nav.styl
@@ -17,12 +17,19 @@
   }
 }
 
-.site-nav {
-  +mobile() {
-    display: none;
-  }
+site-nav-hide-by-default() {
+  --scroll-height: 0;
+  height: 0;
+  overflow: hidden;
+  transition: height $transition-ease;
 
   .site-nav-on & {
-    display: block;
+    height: var(--scroll-height);
+  }
+}
+
+.site-nav {
+  +mobile() {
+    site-nav-hide-by-default();
   }
 }

--- a/source/css/_common/outline/header/site-nav.styl
+++ b/source/css/_common/outline/header/site-nav.styl
@@ -23,7 +23,12 @@ site-nav-hide-by-default() {
   overflow: hidden;
   transition: height $transition-ease;
 
-  .site-nav-on & {
+  body:not(.site-nav-on) & .animated {
+    -webkit-animation: none;
+    animation: none;
+  }
+
+  body.site-nav-on & {
     height: var(--scroll-height);
   }
 }

--- a/source/css/_common/outline/header/site-nav.styl
+++ b/source/css/_common/outline/header/site-nav.styl
@@ -17,21 +17,6 @@
   }
 }
 
-site-nav-hide-by-default() {
-  --scroll-height: 0;
-  height: 0;
-  overflow: hidden;
-  transition: height $transition-ease;
-
-  body:not(.site-nav-on) & .animated {
-    animation: none;
-  }
-
-  body.site-nav-on & {
-    height: var(--scroll-height);
-  }
-}
-
 .site-nav {
   +mobile() {
     site-nav-hide-by-default();

--- a/source/css/_common/outline/header/site-nav.styl
+++ b/source/css/_common/outline/header/site-nav.styl
@@ -24,7 +24,6 @@ site-nav-hide-by-default() {
   transition: height $transition-ease;
 
   body:not(.site-nav-on) & .animated {
-    -webkit-animation: none;
     animation: none;
   }
 

--- a/source/css/_mixins.styl
+++ b/source/css/_mixins.styl
@@ -219,3 +219,18 @@ toggle-close($position) {
     }
   }
 }
+
+site-nav-hide-by-default() {
+  --scroll-height: 0;
+  height: 0;
+  overflow: hidden;
+  transition: height $transition-ease;
+
+  body:not(.site-nav-on) & .animated {
+    animation: none;
+  }
+
+  body.site-nav-on & {
+    height: var(--scroll-height);
+  }
+}

--- a/source/css/_schemes/Pisces/_menu.styl
+++ b/source/css/_schemes/Pisces/_menu.styl
@@ -1,6 +1,6 @@
 .site-nav {
   +tablet() {
-    display: none;
+    site-nav-hide-by-default();
   }
 }
 

--- a/source/js/next-boot.js
+++ b/source/js/next-boot.js
@@ -12,35 +12,8 @@ NexT.boot.registerEvents = function() {
     event.currentTarget.classList.toggle('toggle-close');
     const siteNav = document.querySelector('.site-nav');
     if (!siteNav) return;
-    const animateAction = document.body.classList.contains('site-nav-on');
-    const height = NexT.utils.getComputedStyle(siteNav);
-    siteNav.style.height = animateAction ? height : 0;
-    const toggle = () => document.body.classList.toggle('site-nav-on');
-    const begin = () => {
-      siteNav.style.overflow = 'hidden';
-    };
-    const complete = () => {
-      siteNav.style.overflow = '';
-      siteNav.style.height = '';
-    };
-    window.anime(Object.assign({
-      targets : siteNav,
-      duration: 200,
-      height  : animateAction ? [height, 0] : [0, height],
-      easing  : 'linear'
-    }, animateAction ? {
-      begin,
-      complete: () => {
-        complete();
-        toggle();
-      }
-    } : {
-      begin: () => {
-        begin();
-        toggle();
-      },
-      complete
-    }));
+    siteNav.style.setProperty('--scroll-height', siteNav.scrollHeight + 'px');
+    document.body.classList.toggle('site-nav-on');
   });
 
   const duration = 200;

--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -290,17 +290,6 @@ NexT.utils = {
     });
   },
 
-  getComputedStyle: function(element) {
-    const clone = element.cloneNode(true);
-    clone.style.position = 'absolute';
-    clone.style.visibility = 'hidden';
-    clone.style.display = 'block';
-    element.parentNode.appendChild(clone);
-    const height = clone.clientHeight;
-    element.parentNode.removeChild(clone);
-    return height;
-  },
-
   /**
    * Init Sidebar & TOC inner dimensions on all pages and for all schemes.
    * Need for Sidebar/TOC inner scrolling if content taller then viewport.


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [x] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
NexT uses Anime.js and `NexT.utils.getComputedStyle` to animate `.site-nav` element.
However, Anime.js is scheduled to be replaced as the roadmap describes; `NexT.utils.getComputedStyle` **acturally** returns the `clientHeight` of an element, and it clones the element, which lowers the performance - I believe no one should use it.

Issue resolved:

## What is the new behavior?
<!-- Description about this pull, in several words -->
1. Use of CSS variables and transitions.
2. Deleted `NexT.utils.getComputedStyle` function. (I don't think it is a "functional change" since this function is only used in the case here.)
    `NexT.utils.getComputedStyle` is designed to get the `clientHeight` when the element is **fully** showed, that's the reason why it clones a invisible copy of the element. But, we can use `scrollHeight` directly. They have the same result since [`scrollHeight` is measured in the same way as `clientHeight` according to MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight).
    The [browser compatibility of `scrollHeight`](https://caniuse.com/mdn-api_element_scrollheight) is not a concern, too.

- Link to demo site with this changes:
- Screenshots with this changes:

### How to use?

In NexT `_config.yml`:
```yml

```
