### PR TITLE
Dynamic Dark Mode

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,12 +37,24 @@ custom_file_path:
 
 # Schemes
 scheme: Muse
-#scheme: Mist
+# scheme: Mist
 #scheme: Pisces
 #scheme: Gemini
 
 # Dark Mode
-darkmode: false
+darkmode: 
+  enable: false
+  bottom: '32px'
+  right: '32px' 
+  left: 'unset' 
+  time: '0.5s' 
+  mixColor: '#fff'
+  backgroundColor: '#fff'
+  buttonColorDark: '#100f2c'
+  buttonColorLight: '#fff'
+  saveInCookies: true
+  label: '🌓'
+  autoMatchOsTheme: true
 
 
 # ---------------------------------------------------------------

--- a/_vendors.yml
+++ b/_vendors.yml
@@ -137,3 +137,7 @@ canvas_ribbon:
   version: 1.0.2
   file: dist/ribbon.min.js
   unavailable: [cdnjs]
+darkmode_js:
+  name: darkmode-js
+  version: 1.5.7
+  file: lib/darkmode-js.min.js

--- a/layout/_scripts/vendors.njk
+++ b/layout/_scripts/vendors.njk
@@ -5,3 +5,24 @@
 {%- for name in js_vendors() %}
   <script src="{{ url_for(theme.vendors[name]) }}"></script>
 {%- endfor %}
+
+{# Customize darkmode.js - Invokation #}
+{%- if theme.darkmode.enable %}
+<script>
+var options = {
+  bottom: '{{ theme.darkmode.bottom }}',
+  right: '{{ theme.darkmode.right }}',
+  left: '{{ theme.darkmode.left }}',
+  time: '{{ theme.darkmode.time }}',
+  mixColor: '{{ theme.darkmode.mixColor }}',
+  backgroundColor: '{{ theme.darkmode.backgroundColor }}', 
+  buttonColorDark: '{{ theme.darkmode.buttonColorDark }}', 
+  buttonColorLight: '{{ theme.darkmode.buttonColorLight }}',
+  saveInCookies: {{ theme.darkmode.saveInCookies }},
+  label: '{{ theme.darkmode.label }}',
+  autoMatchOsTheme: {{ theme.darkmode.autoMatchOsTheme }},
+}
+const darkmode = new Darkmode(options);
+darkmode.showWidget();
+</script>
+{%- endif %}

--- a/scripts/helpers/next-vendors.js
+++ b/scripts/helpers/next-vendors.js
@@ -26,5 +26,8 @@ hexo.extend.helper.register('js_vendors', function() {
   if (theme.pangu) {
     vendors.push('pangu');
   }
+  if (theme.darkmode) {
+    vendors.push('darkmode_js');
+  }
   return vendors;
 });

--- a/source/css/_colors.styl
+++ b/source/css/_colors.styl
@@ -66,6 +66,10 @@ body {
 
   .brand {
     color: #333;
-    }
+  }
+  
+  .darkmode-toggle  {
+    z-index: 999999;
+  }
 }    
 

--- a/source/css/_colors.styl
+++ b/source/css/_colors.styl
@@ -1,4 +1,4 @@
-:root {
+body {
   --body-bg-color: $body-bg-color;
   --content-bg-color: $content-bg-color;
   --card-bg-color: $card-bg-color;
@@ -25,41 +25,47 @@
   --highlight-gutter-foreground: $highlight-gutter-foreground;
 }
 
-if (hexo-config('darkmode')) {
-  @media (prefers-color-scheme: dark) {
-    :root {
-      --body-bg-color: $body-bg-color-dark;
-      --content-bg-color: $content-bg-color-dark;
-      --card-bg-color: $card-bg-color-dark;
-      --text-color: $text-color-dark;
-      --blockquote-color: $blockquote-color-dark;
-      --link-color: $link-color-dark;
-      --link-hover-color: $link-hover-color-dark;
-      --brand-color: $brand-color-dark;
-      --brand-hover-color: $brand-hover-color-dark;
-      --table-row-odd-bg-color: $table-row-odd-bg-color-dark;
-      --table-row-hover-bg-color: $table-row-hover-bg-color-dark;
-      --menu-item-bg-color: $menu-item-bg-color-dark;
+.darkmode--activated {
+  --body-bg-color: $body-bg-color-dark;
+  --content-bg-color: $content-bg-color-dark;
+  --card-bg-color: $card-bg-color-dark;
+  --text-color: $text-color-dark;
+  --blockquote-color: $blockquote-color-dark;
+  --link-color: $link-color-dark;
+  --link-hover-color: $link-hover-color-dark;
+  --brand-color: $brand-color-dark;
+  --brand-hover-color: $brand-hover-color-dark;
+  --table-row-odd-bg-color: $table-row-odd-bg-color-dark;
+  --table-row-hover-bg-color: $table-row-hover-bg-color-dark;
+  --menu-item-bg-color: $menu-item-bg-color-dark;
 
-      --btn-default-bg: $btn-default-bg-dark;
-      --btn-default-color: $btn-default-color-dark;
-      --btn-default-border-color: $btn-default-border-color-dark;
-      --btn-default-hover-bg: $btn-default-hover-bg-dark;
-      --btn-default-hover-color: $btn-default-hover-color-dark;
-      --btn-default-hover-border-color: $btn-default-hover-border-color-dark;
+  --btn-default-bg: $btn-default-bg-dark;
+  --btn-default-color: $btn-default-color-dark;
+  --btn-default-border-color: $btn-default-border-color-dark;
+  --btn-default-hover-bg: $btn-default-hover-bg-dark;
+  --btn-default-hover-color: $btn-default-hover-color-dark;
+  --btn-default-hover-border-color: $btn-default-hover-border-color-dark;
 
-      --highlight-background: $highlight-background-dark;
-      --highlight-foreground: $highlight-foreground-dark;
-      --highlight-gutter-background: $highlight-gutter-background-dark;
-      --highlight-gutter-foreground: $highlight-gutter-foreground-dark;
-    }
+  --highlight-background: $highlight-background-dark;
+  --highlight-foreground: $highlight-foreground-dark;
+  --highlight-gutter-background: $highlight-gutter-background-dark;
+  --highlight-gutter-foreground: $highlight-gutter-foreground-dark;
 
-    img {
-      opacity: .75;
+  img {
+    opacity: .75;
 
-      &:hover {
-        opacity: .9;
-      }
+    &:hover {
+      opacity: .9;
     }
   }
-}
+
+  code {
+    color: #69dbdc;
+    background: transparent;
+  }
+
+  .brand {
+    color: #333;
+    }
+}    
+


### PR DESCRIPTION
## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

We added `darkmode_js` to the project and optimized the dark mode in the code section so that the user can switch the mode manually with just one click and it has a very cool animation.

## What is the new behavior?

![image](https://user-images.githubusercontent.com/51934415/111880087-4817cc00-89e4-11eb-9b85-5d1a82166e3c.png)
![image](https://user-images.githubusercontent.com/51934415/111880136-8614f000-89e4-11eb-832e-c52c303b5f63.png)


### How to use?

In NexT `_config.yml`:
```yml
# Dark Mode
darkmode: 
  enable: true
  bottom: '32px'
  right: '32px' 
  left: 'unset' 
  time: '0.5s' 
  mixColor: '#fff'
  backgroundColor: '#fff'
  buttonColorDark: '#100f2c'
  buttonColorLight: '#fff'
  saveInCookies: true
  label: '🌓'
  autoMatchOsTheme: true
```

Thx
