### PR TITLE
Add aria-label for buttons and selects

### DIFF
--- a/languages/en.yml
+++ b/languages/en.yml
@@ -102,6 +102,8 @@ accessibility:
   nav_toggle: Toggle navigation bar
   prev_page: Previous page
   next_page: Next page
+  back_to_top: Back to top
+  select_lang: Select language
 
 symbols_count_time:
   count: Symbols count in article

--- a/languages/zh-CN.yml
+++ b/languages/zh-CN.yml
@@ -87,6 +87,8 @@ accessibility:
   nav_toggle: 切换导航栏
   prev_page: 上一页
   next_page: 下一页
+  back_to_top: 返回顶部
+  select_lang: 选择语言
 symbols_count_time:
   count: 本文字数
   count_total: 站点总字数

--- a/layout/_macro/sidebar.njk
+++ b/layout/_macro/sidebar.njk
@@ -39,7 +39,7 @@
       </div>
 
       {%- if theme.back2top.enable and theme.back2top.sidebar %}
-        <div class="back-to-top animated" role="button" aria-label="Back to Top">
+        <div class="back-to-top animated" role="button" aria-label="{{ __('accessibility.back_to_top') }}">
           <i class="fa fa-arrow-up"></i>
           <span>0%</span>
         </div>

--- a/layout/_macro/sidebar.njk
+++ b/layout/_macro/sidebar.njk
@@ -39,7 +39,7 @@
       </div>
 
       {%- if theme.back2top.enable and theme.back2top.sidebar %}
-        <div class="back-to-top animated" role="button">
+        <div class="back-to-top animated" role="button" aria-label="Back to Top">
           <i class="fa fa-arrow-up"></i>
           <span>0%</span>
         </div>

--- a/layout/_partials/languages.njk
+++ b/layout/_partials/languages.njk
@@ -5,7 +5,7 @@
       <span>{{ language_name(page.lang) }}</span>
       <i class="fa fa-angle-up" aria-hidden="true"></i>
     </label>
-    <select class="lang-select" data-canonical="" aria-label="Select Language">
+    <select class="lang-select" data-canonical="" aria-label="{{ __('accessibility.select_lang') }}">
       {% for language in languages %}
         <option value="{{ language }}" data-href="{{ i18n_path(language) }}" selected="">
           {{ language_name(language) }}

--- a/layout/_partials/languages.njk
+++ b/layout/_partials/languages.njk
@@ -5,7 +5,7 @@
       <span>{{ language_name(page.lang) }}</span>
       <i class="fa fa-angle-up" aria-hidden="true"></i>
     </label>
-    <select class="lang-select" data-canonical="">
+    <select class="lang-select" data-canonical="" aria-label="Select Language">
       {% for language in languages %}
         <option value="{{ language }}" data-href="{{ i18n_path(language) }}" selected="">
           {{ language_name(language) }}

--- a/layout/_partials/widgets.njk
+++ b/layout/_partials/widgets.njk
@@ -1,5 +1,5 @@
 {%- if theme.back2top.enable and not theme.back2top.sidebar %}
-  <div class="back-to-top" role="button">
+  <div class="back-to-top" role="button" aria-label="Back to Top">
     <i class="fa fa-arrow-up"></i>
     <span>0%</span>
   </div>

--- a/layout/_partials/widgets.njk
+++ b/layout/_partials/widgets.njk
@@ -1,5 +1,5 @@
 {%- if theme.back2top.enable and not theme.back2top.sidebar %}
-  <div class="back-to-top" role="button" aria-label="Back to Top">
+  <div class="back-to-top" role="button" aria-label="{{ __('accessibility.back_to_top') }}">
     <i class="fa fa-arrow-up"></i>
     <span>0%</span>
   </div>


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [ ] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue resolved: lighthouse score is low since there is no aria-label

## What is the new behavior?
<!-- Description about this pull, in several words -->
Add aria-label for buttons and selects

<!--
- Link to demo site with this changes:
- Screenshots with this changes:
-->

<!--
### How to use?

In NexT `_config.yml`:
```yml

```
-->
