### PR TITLE
Disable `margin` animation of `<body>`

### DIFF
--- a/source/css/_common/scaffolding/base.styl
+++ b/source/css/_common/scaffolding/base.styl
@@ -15,7 +15,7 @@ body {
   line-height: $line-height-base;
   min-height: 100%;
   position: relative;
-  transition: all $transition-ease;
+  transition: padding $transition-ease;
 }
 
 h1, h2, h3, h4, h5, h6 {

--- a/source/css/_schemes/Muse/_sidebar.styl
+++ b/source/css/_schemes/Muse/_sidebar.styl
@@ -1,7 +1,7 @@
 if (hexo-config('sidebar.position') == 'right') {
   .sidebar-active {
     +desktop() {
-      margin-right: $sidebar-desktop;
+      padding-right: $sidebar-desktop;
     }
   }
 
@@ -15,7 +15,7 @@ if (hexo-config('sidebar.position') == 'right') {
 } else {
   .sidebar-active {
     +desktop() {
-      margin-left: $sidebar-desktop;
+      padding-left: $sidebar-desktop;
     }
   }
 


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->
`margin` of `<body>` is changed when sidebar becomes active **or** an image is opened by fancybox. The two events in the two conditions share the same CSS transition.

Issue resolved: #231

## What is the new behavior?
<!-- Description about this pull, in several words -->
Change `padding` instead of `margin` when sidebar becomes active, and apply transition effects to `padding` only.

Most of these will revert some changes of https://github.com/next-theme/hexo-theme-next/commit/9ec4d87ddc41b32d9bd5728298fe34b6595726d2 (in [source/css/_schemes/Muse/_sidebar.styl](https://github.com/next-theme/hexo-theme-next/commit/9ec4d87ddc41b32d9bd5728298fe34b6595726d2#diff-9d095b465ebb117989ecb9b7780d3fbd3dc94d0d9ca50399aa1438e0ba9d2d1c)).
Wondering if there are something I missed out.

- Link to demo site with this changes:
- Screenshots with this changes:

### How to use?

In NexT `_config.yml`:
```yml

```
