### PR TITLE
Fix scrolling for site overview

### DIFF
--- a/layout/_macro/sidebar.njk
+++ b/layout/_macro/sidebar.njk
@@ -32,11 +32,12 @@
         <!--/noindex-->
 
         <div class="site-overview-wrap sidebar-panel">
-          {{ partial('_partials/sidebar/site-overview.njk', {}, {cache: theme.cache.enable}) }}
+          <div class="site-overview">
+            {{ partial('_partials/sidebar/site-overview.njk', {}, {cache: theme.cache.enable}) }}
 
-          {{- next_inject('sidebar') }}
+            {{- next_inject('sidebar') }}
+          </div>
         </div>
-      </div>
 
       {%- if theme.back2top.enable and theme.back2top.sidebar %}
         <div class="back-to-top animated" role="button" aria-label="{{ __('accessibility.back_to_top') }}">

--- a/source/css/_common/outline/sidebar/index.styl
+++ b/source/css/_common/outline/sidebar/index.styl
@@ -4,6 +4,10 @@
   text-align: center;
 }
 
+.site-overview {
+  max-height: var(--sidebar-wrapper-height);
+}
+
 .site-overview-item:not(:first-child) {
   margin-top: 10px;
 }


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [ ] Pisces | Gemini have been tested.
- [ ] N/A [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->
Cannot scroll to the topmost for site overview.
![site-overview-bad](https://user-images.githubusercontent.com/299873/114119912-89035200-98b9-11eb-8e6c-ea39ad2a6374.png)

Issue resolved:

## What is the new behavior?
<!-- Description about this pull, in several words -->
Should be able to scroll to the topmost.

- Link to demo site with this changes:
- Screenshots with this changes: ![site-overview-good](https://user-images.githubusercontent.com/299873/114119902-830d7100-98b9-11eb-8252-a84e5cc259c3.png)

### How to use?

No change in configuration needed.

In NexT `_config.yml`:
```yml

```
