### PR TITLE
Overlay body scrollbar in all browsers

### DIFF
--- a/source/css/_common/scaffolding/base.styl
+++ b/source/css/_common/scaffolding/base.styl
@@ -20,7 +20,6 @@ body {
   }
   position: relative;
   transition: padding $transition-ease;
-  width: 100vw;
 }
 
 h1, h2, h3, h4, h5, h6 {

--- a/source/css/_common/scaffolding/base.styl
+++ b/source/css/_common/scaffolding/base.styl
@@ -14,8 +14,13 @@ body {
   font-size: $font-size-base;
   line-height: $line-height-base;
   min-height: 100%;
+  overflow-x: hidden;
+  @supports (overflow-x: clip) {
+    overflow-x: clip;
+  }
   position: relative;
   transition: padding $transition-ease;
+  width: 100vw;
 }
 
 h1, h2, h3, h4, h5, h6 {

--- a/source/css/_mixins.styl
+++ b/source/css/_mixins.styl
@@ -108,15 +108,16 @@ font-family-icons($icon = '') {
 }
 
 main-container() {
+  --width: $content-desktop;
   margin: 0 auto;
-  width: $content-desktop;
+  width: var(--width);
 
   +desktop-large() {
-    width: $content-desktop-large;
+    --width: $content-desktop-large;
   }
 
   +desktop-largest() {
-    width: $content-desktop-largest;
+    --width: $content-desktop-largest;
   }
 }
 

--- a/source/css/_mixins.styl
+++ b/source/css/_mixins.styl
@@ -109,7 +109,7 @@ font-family-icons($icon = '') {
 
 main-container() {
   --width: $content-desktop;
-  margin: 0 auto;
+  margin: 0 calc((100vw - var(--width)) / 2);
   width: var(--width);
 
   +desktop-large() {

--- a/source/css/_schemes/Pisces/_layout.styl
+++ b/source/css/_schemes/Pisces/_layout.styl
@@ -2,6 +2,7 @@
   background: var(--content-bg-color);
   border-radius: $border-radius-inner;
   box-shadow: $box-shadow-inner;
+  margin: 0 auto;
   width: $sidebar-desktop;
 
   +tablet-mobile() {
@@ -17,7 +18,6 @@
   display: flex;
   justify-content: space-between;
   main-container();
-  margin: 0 calc((100vw - var(--width)) / 2);
 
   if (hexo-config('sidebar.position') == 'right') {
     flex-direction: row-reverse;

--- a/source/css/_schemes/Pisces/_layout.styl
+++ b/source/css/_schemes/Pisces/_layout.styl
@@ -17,6 +17,7 @@
   display: flex;
   justify-content: space-between;
   main-container();
+  margin: 0 calc((100vw - var(--width)) / 2);
 
   if (hexo-config('sidebar.position') == 'right') {
     flex-direction: row-reverse;


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Resolves #18, resolves #176 

## What is the new behavior?
<!-- Description about this pull, in several words -->
Make the scrollbar of `<body>` overlays on top of content. In theory, the same effect as webkit's `overflow: overlay` (non-standardized and not supported by all).

- Link to demo site with this changes: [sliphua.buggy.work](https://sliphua.buggy.work)
- Screenshots with this changes:

### How to use?

In NexT `_config.yml`:
```yml

```
