### PR TITLE
New body scrollbar style option

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -352,6 +352,9 @@ mobile_layout_economy: false
 # Android Chrome header panel color ($brand-bg / $headband-bg => $black-deep).
 android_chrome_color: "#222"
 
+# Place the scrollbar of <body> over the content.
+overlay_body_scrollbar: false
+
 codeblock:
   # Code Highlight theme
   # All available themes: https://theme-next.js.org/highlight/

--- a/_config.yml
+++ b/_config.yml
@@ -352,8 +352,8 @@ mobile_layout_economy: false
 # Android Chrome header panel color ($brand-bg / $headband-bg => $black-deep).
 android_chrome_color: "#222"
 
-# Place the scrollbar of <body> over the content.
-overlay_body_scrollbar: false
+# Available values: default | overlay | stable
+body_scrollbar_style: default
 
 codeblock:
   # Code Highlight theme

--- a/_config.yml
+++ b/_config.yml
@@ -352,8 +352,12 @@ mobile_layout_economy: false
 # Android Chrome header panel color ($brand-bg / $headband-bg => $black-deep).
 android_chrome_color: "#222"
 
-# Available values: default | overlay | stable
-body_scrollbar_style: default
+# Override browsers' default behavior.
+body_scrollbar:
+  # Place the scrollbar over the content.
+  overlay: false
+  # Present the scrollbar even if the content is not overflowing.
+  stable: false
 
 codeblock:
   # Code Highlight theme

--- a/source/css/_common/scaffolding/base.styl
+++ b/source/css/_common/scaffolding/base.styl
@@ -17,12 +17,14 @@ body {
   position: relative;
   transition: padding $transition-ease;
 
-  if (hexo-config('overlay_body_scrollbar')) {
+  if (hexo-config('body_scrollbar_style') == 'overlay') {
     overflow-x: hidden;
     @supports (overflow-x: clip) {
       overflow-x: clip;
     }
     width: 100vw;
+  } else if (hexo-config('body_scrollbar_style') == 'stable') {
+    overflow-y: scroll;
   }
 }
 

--- a/source/css/_common/scaffolding/base.styl
+++ b/source/css/_common/scaffolding/base.styl
@@ -14,10 +14,6 @@ body {
   font-size: $font-size-base;
   line-height: $line-height-base;
   min-height: 100%;
-  overflow-x: hidden;
-  @supports (overflow-x: clip) {
-    overflow-x: clip;
-  }
   position: relative;
   transition: padding $transition-ease;
 }

--- a/source/css/_common/scaffolding/base.styl
+++ b/source/css/_common/scaffolding/base.styl
@@ -16,6 +16,14 @@ body {
   min-height: 100%;
   position: relative;
   transition: padding $transition-ease;
+
+  if (hexo-config('overlay_body_scrollbar')) {
+    overflow-x: hidden;
+    @supports (overflow-x: clip) {
+      overflow-x: clip;
+    }
+    width: 100vw;
+  }
 }
 
 h1, h2, h3, h4, h5, h6 {

--- a/source/css/_common/scaffolding/base.styl
+++ b/source/css/_common/scaffolding/base.styl
@@ -17,13 +17,15 @@ body {
   position: relative;
   transition: padding $transition-ease;
 
-  if (hexo-config('body_scrollbar_style') == 'overlay') {
+  if (hexo-config('body_scrollbar.overlay')) {
     overflow-x: hidden;
     @supports (overflow-x: clip) {
       overflow-x: clip;
     }
     width: 100vw;
-  } else if (hexo-config('body_scrollbar_style') == 'stable') {
+  }
+
+  if (hexo-config('body_scrollbar.stable')) {
     overflow-y: scroll;
   }
 }

--- a/source/css/_mixins.styl
+++ b/source/css/_mixins.styl
@@ -108,16 +108,15 @@ font-family-icons($icon = '') {
 }
 
 main-container() {
-  --width: $content-desktop;
-  margin: 0 calc((100vw - var(--width)) / 2);
-  width: var(--width);
+  margin: 0 auto;
+  width: $content-desktop;
 
   +desktop-large() {
-    --width: $content-desktop-large;
+    width: $content-desktop-large;
   }
 
   +desktop-largest() {
-    --width: $content-desktop-largest;
+    width: $content-desktop-largest;
   }
 }
 

--- a/source/css/_schemes/Pisces/_layout.styl
+++ b/source/css/_schemes/Pisces/_layout.styl
@@ -2,7 +2,6 @@
   background: var(--content-bg-color);
   border-radius: $border-radius-inner;
   box-shadow: $box-shadow-inner;
-  margin: 0 auto;
   width: $sidebar-desktop;
 
   +tablet-mobile() {


### PR DESCRIPTION
Reverts next-theme/hexo-theme-next#246

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?

I do apologize that I did not realize using `--width` for both `margin` and `width` in `main-container`, will make it necessary to set `--width` instead of `width` **everytime** we want to change the width of the related elements. In my recent tests, it HAS caused visible problems which did not mentioned in #246, and increases the difficulty of the development in the future.

## What is the new behavior?

Users needing this functionality should ~~use the original method mentioned in https://github.com/next-theme/hexo-theme-next/issues/176#issuecomment-808746102 , which is editing their custom style file to apply these rules:~~ set the option `body_scrollbar.overlay` to `true` to place the scrollbar on top of the content.

```stylus
body {
  width: 100vw;
  overflow-x: hidden;
  @supports (overflow-x: clip) {
    overflow-x: clip;
  }
}
```

NexT will not apply these rules by default for problems like https://github.com/next-theme/hexo-theme-next/pull/246#issuecomment-817440475 .

**(Current Status: Option Added, PR Renamed)** I think it is better to make the code above an option exists in NexT. Will try to make commits for it and rename this PR if no one complaints.

---

The new `stable` option only reflects to `overflow-y: scroll` at the moment. Its name and behavior may be changed in later commits, if someone has a better suggestion.

### How to use?

In NexT `_config.yml`:
```yml
# Override browsers' default behavior.
body_scrollbar:
  # Place the scrollbar over the content.
  overlay: false
  # Present the scrollbar even if the content is not overflowing.
  stable: false
```
