### PR TITLE
Fix anchors in home page

### DIFF
--- a/scripts/filters/home.js
+++ b/scripts/filters/home.js
@@ -1,0 +1,17 @@
+/* global hexo */
+
+'use strict';
+
+hexo.extend.filter.register('after_render:html', (str, {page}) => {
+  if (!page.__index) return;
+
+  // Fix anchor by prefixing with the relative path of the target article.
+  let postIndex = 0;
+  return str.replace(/(?<=<article[^>]*>)[^]+?(?=<\/article>)/g, (article) => {
+    const pathAdded = article.replace(/(?<=<a[^>]* href=")[^"]+(?="[^>]* class="(anchor-link|headerlink)"[^>]*>)/g, (href) => {
+      return page.posts.data[postIndex].path + href;
+    });
+    postIndex++;
+    return pathAdded;
+  });
+});


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was made (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
   - [ ] `hexo-renderer-markdown-it` has been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->
Anchors in home page having a high risk to conflict with each other, or become invalid as home page changes frequently.

Issue resolved:

## What is the new behavior?
In home page, anchors of each article be prefixed by the article's relative path.

- Link to demo site with this changes: [sliphua.work](https://sliphua.work)
- Screenshots with this changes:

### How to use?

In NexT `_config.yml`:
```yml

```
