### PR TITLE
Make #241 backward compatible

### DIFF
--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -337,53 +337,66 @@ NexT.utils = {
     }
   },
 
-  getScript: (url, {
-    condition = false,
-    attributes: {
-      id = '',
-      async = false,
-      defer = false,
-      crossOrigin = '',
-      dataset = {},
-      ...otherAttributes
-    } = {},
-    parentNode = null
-  } = {}) => new Promise((resolve, reject) => {
-    if (condition) {
-      resolve();
-    } else {
-      const script = document.createElement('script');
-
-      if (id) script.id = id;
-      if (crossOrigin) script.crossOrigin = crossOrigin;
-      script.async = async;
-      script.defer = defer;
-      Object.assign(script.dataset, dataset);
-      Object.entries(otherAttributes).forEach(([name, value]) => {
-        script.setAttribute(name, String(value));
-      });
-
-      script.onload = resolve;
-      script.onerror = reject;
-
-      script.src = url;
-      (parentNode || document.head).appendChild(script);
+  getScript: function(url, options = {}, legacyCondition) {
+    if (typeof options === 'function') {
+      return this.getScript(url, {
+        condition: legacyCondition
+      }).then(options);
     }
-  }),
+    const {
+      condition = false,
+      attributes: {
+        id = '',
+        async = false,
+        defer = false,
+        crossOrigin = '',
+        dataset = {},
+        ...otherAttributes
+      } = {},
+      parentNode = null
+    } = options;
+    return new Promise((resolve, reject) => {
+      if (condition) {
+        resolve();
+      } else {
+        const script = document.createElement('script');
 
-  loadComments: (selector) => new Promise((resolve) => {
-    const element = document.querySelector(selector);
-    if (!CONFIG.comments.lazyload || !element) {
-      resolve();
-      return;
-    }
-    const intersectionObserver = new IntersectionObserver((entries, observer) => {
-      const entry = entries[0];
-      if (!entry.isIntersecting) return;
+        if (id) script.id = id;
+        if (crossOrigin) script.crossOrigin = crossOrigin;
+        script.async = async;
+        script.defer = defer;
+        Object.assign(script.dataset, dataset);
+        Object.entries(otherAttributes).forEach(([name, value]) => {
+          script.setAttribute(name, String(value));
+        });
 
-      resolve();
-      observer.disconnect();
+        script.onload = resolve;
+        script.onerror = reject;
+
+        script.src = url;
+        (parentNode || document.head).appendChild(script);
+      }
     });
-    intersectionObserver.observe(element);
-  })
+  },
+
+  loadComments: function(selector, legacyCallback) {
+    if (legacyCallback) {
+      return this.loadComments(selector).then(legacyCallback);
+    }
+    return new Promise((resolve) => {
+      const element = document.querySelector(selector);
+      if (!CONFIG.comments.lazyload || !element) {
+        resolve();
+        return;
+      }
+      const intersectionObserver = new IntersectionObserver((entries, observer) => {
+        const entry = entries[0];
+        if (!entry.isIntersecting) return;
+
+        resolve();
+        observer.disconnect();
+      });
+      intersectionObserver.observe(element);
+    });
+  }
 };


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue resolved: #258 

## What is the new behavior?
<!-- Description about this pull, in several words -->
Make `NexT.utils.getScript` and `NexT.utils.loadComments` backward compatible

- Link to demo site with this changes:
- Screenshots with this changes:

### How to use?

In NexT `_config.yml`:
```yml

```
