### PR TITLE
Fix overwritten of non-object in CONFIG

### DIFF
--- a/source/js/config.js
+++ b/source/js/config.js
@@ -36,22 +36,30 @@ if (!window.NexT) window.NexT = {};
         existing = variableConfig[name];
       }
 
-      let override = overrideConfig[name];
+      // For unset override and mixable existing
       if (!(name in overrideConfig) && typeof existing === 'object') {
-        override = {};
-        overrideConfig[name] = override;
+        // Get ready to mix.
+        overrideConfig[name] = {};
       }
 
-      if (typeof override === 'object') {
-        return new Proxy({...existing, ...override}, {
-          set(target, prop, value) {
-            override[prop] = value;
-            return true;
-          }
-        });
-      } else if (name in overrideConfig) {
+      if (name in overrideConfig) {
+        const override = overrideConfig[name];
+
+        // When mixable
+        if (typeof override === 'object' && typeof existing === 'object') {
+          // Mix, proxy changes to the override.
+          return new Proxy({...existing, ...override}, {
+            set(target, prop, value) {
+              override[prop] = value;
+              return true;
+            }
+          });
+        }
+
         return override;
       }
+
+      // Only when not mixable and override hasn't been set.
       return existing;
     }
   });

--- a/source/js/config.js
+++ b/source/js/config.js
@@ -37,7 +37,7 @@ if (!window.NexT) window.NexT = {};
       }
 
       let override = overrideConfig[name];
-      if (override === undefined && typeof existing === 'object') {
+      if (!(name in overrideConfig) && typeof existing === 'object') {
         override = {};
         overrideConfig[name] = override;
       }
@@ -49,6 +49,8 @@ if (!window.NexT) window.NexT = {};
             return true;
           }
         });
+      } else if (name in overrideConfig) {
+        return override;
       }
       return existing;
     }

--- a/source/js/config.js
+++ b/source/js/config.js
@@ -50,6 +50,7 @@ if (!window.NexT) window.NexT = {};
           // Mix, proxy changes to the override.
           return new Proxy({...existing, ...override}, {
             set(target, prop, value) {
+              target[prop] = value;
               override[prop] = value;
               return true;
             }


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was made (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
Properties of `CONFIG` can be overriden only when its value is an Object.

## What is the new behavior?
Make the properties of any type overridable.

- Link to demo site with this changes:
- Screenshots with this changes:

### How to use?

In NexT `_config.yml`:
```yml

```
