### PR TITLE
Add isso client's configuation items.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -649,7 +649,40 @@ utterances:
 
 # Isso
 # For more information: https://posativ.org/isso/
-isso: # <data_isso>
+isso: 
+  url: # Your isso server domain
+  lang: zh # Set language
+  # Set to true when spam guard is configured with reply-to-self = true.
+  reply_to_self: "false" 
+  # Set to true when spam guard is configured with require-author = true.
+  require_author: "false" 
+  # Set to true when spam guard is configured with require-email = true.
+  require_email: "false" 
+  # Set to true when reply notifications is configured with reply-notifications = true.
+  reply_notifications: "false" 
+  # Number of top level (or nested) comments to show by default. If some comments are not shown, an “X Hidden” link is shown.
+  # Set to “inf” to show all, or “0” to hide all.
+  max_comments_top: "10"
+  max_comments_nested: "5"
+  # Number of comments to reveal on clicking the “X Hidden” link.
+  reveal_on_click: "5"
+  # Enable or disable avatar generation.
+  avatar: "true"
+  # Set avatar background color. Any valid CSS color will do.
+  avatar_bg: "#f0f0f0"
+  # Set avatar foreground color. Up to 8 colors are possible. 
+  # The default color scheme is based in this color palette. 
+  # Multiple colors must be separated by space. 
+  # If you use less than eight colors and not a multiple of 2, the color distribution is not even.
+  avatar_fg: "#9abf88 #5698c4 #e279a3 #9163b6 ..."
+  # Enable or disable voting feature on the client side.
+  vote: "true"
+  # List of vote levels used to customize comment appearance based on score. 
+  # Provide a comma-separated values (eg. “0,5,10,25,100”) or a JSON array (eg. “[-5,5,15]”).
+  vote_levels: ""
+  # Enable or disable the addition of a link to the feed for the comment thread. 
+  # The link will only be valid if the appropriate setting, in [rss] section, is also enabled server-side.
+  feed: "false"
 
 
 # ---------------------------------------------------------------

--- a/source/js/third-party/comments/isso.js
+++ b/source/js/third-party/comments/isso.js
@@ -7,21 +7,21 @@ document.addEventListener('page:loaded', () => {
     .then(() => NexT.utils.getScript(`${CONFIG.isso.url}js/embed.min.js`, {
       attributes: {
         dataset: {
-          isso: `${CONFIG.isso.url}`,
-          issoLang: `${CONFIG.isso.lang }`,
-          issoReplyToSelf: `${CONFIG.isso.reply_to_self }`,
-          issoRequireAuthor: `${CONFIG.isso.require_author }`,
-          issoRequireEmail: `${CONFIG.isso.require_email }`,
-          issoReplyNotifications: `${CONFIG.isso.reply_notifications}`,
-          issoMaxCommentsTop: `${CONFIG.isso.max_comments_top }`,
-          issoMaxCommentsNested: `${CONFIG.isso.max_comments_nested }`,
-          issoRevealOnClick: `${CONFIG.isso.reveal_on_click }`,
-          issoAvatar: `${CONFIG.isso.avatar }`,
-          issoAvatarBg: `${CONFIG.isso.avatar_bg }`,
-          issoAvatarFg: `${CONFIG.isso.avatar_fg }`,
-          issoVote: `${CONFIG.isso.vote }`,
-          issoVoteLevels: `${CONFIG.isso.vote_levels }`,
-          issoFeed: `${CONFIG.isso.feed }`
+          isso : `${CONFIG.isso.url}`,
+          issoLang : `${CONFIG.isso.lang }`,
+          issoReplyToSelf : `${CONFIG.isso.reply_to_self }`,
+          issoRequireAuthor : `${CONFIG.isso.require_author }`,
+          issoRequireEmail : `${CONFIG.isso.require_email }`,
+          issoReplyNotifications : `${CONFIG.isso.reply_notifications}`,
+          issoMaxCommentsTop : `${CONFIG.isso.max_comments_top }`,
+          issoMaxCommentsNested : `${CONFIG.isso.max_comments_nested }`,
+          issoRevealOnClick : `${CONFIG.isso.reveal_on_click }`,
+          issoAvatar : `${CONFIG.isso.avatar }`,
+          issoAvatarBg : `${CONFIG.isso.avatar_bg }`,
+          issoAvatarFg : `${CONFIG.isso.avatar_fg }`,
+          issoVote : `${CONFIG.isso.vote }`,
+          issoVoteLevels : `${CONFIG.isso.vote_levels }`,
+          issoFeed : `${CONFIG.isso.feed }`
         }
       },
       parentNode: document.querySelector('#isso-thread')

--- a/source/js/third-party/comments/isso.js
+++ b/source/js/third-party/comments/isso.js
@@ -8,20 +8,20 @@ document.addEventListener('page:loaded', () => {
       attributes: {
         dataset: {
           isso : `${CONFIG.isso.url}`,
-          issoLang : `${CONFIG.isso.lang }`,
-          issoReplyToSelf : `${CONFIG.isso.reply_to_self }`,
-          issoRequireAuthor : `${CONFIG.isso.require_author }`,
-          issoRequireEmail : `${CONFIG.isso.require_email }`,
+          issoLang : `${CONFIG.isso.lang}`,
+          issoReplyToSelf : `${CONFIG.isso.reply_to_self}`,
+          issoRequireAuthor : `${CONFIG.isso.require_author}`,
+          issoRequireEmail : `${CONFIG.isso.require_email}`,
           issoReplyNotifications : `${CONFIG.isso.reply_notifications}`,
-          issoMaxCommentsTop : `${CONFIG.isso.max_comments_top }`,
-          issoMaxCommentsNested : `${CONFIG.isso.max_comments_nested }`,
-          issoRevealOnClick : `${CONFIG.isso.reveal_on_click }`,
-          issoAvatar : `${CONFIG.isso.avatar }`,
-          issoAvatarBg : `${CONFIG.isso.avatar_bg }`,
-          issoAvatarFg : `${CONFIG.isso.avatar_fg }`,
-          issoVote : `${CONFIG.isso.vote }`,
-          issoVoteLevels : `${CONFIG.isso.vote_levels }`,
-          issoFeed : `${CONFIG.isso.feed }`
+          issoMaxCommentsTop : `${CONFIG.isso.max_comments_top}`,
+          issoMaxCommentsNested : `${CONFIG.isso.max_comments_nested}`,
+          issoRevealOnClick : `${CONFIG.isso.reveal_on_click}`,
+          issoAvatar : `${CONFIG.isso.avatar}`,
+          issoAvatarBg : `${CONFIG.isso.avatar_bg}`,
+          issoAvatarFg : `${CONFIG.isso.avatar_fg}`,
+          issoVote : `${CONFIG.isso.vote}`,
+          issoVoteLevels : `${CONFIG.isso.vote_levels}`,
+          issoFeed : `${CONFIG.isso.feed}`
         }
       },
       parentNode: document.querySelector('#isso-thread')

--- a/source/js/third-party/comments/isso.js
+++ b/source/js/third-party/comments/isso.js
@@ -4,10 +4,24 @@ document.addEventListener('page:loaded', () => {
   if (!CONFIG.page.comments) return;
 
   NexT.utils.loadComments('#isso-thread')
-    .then(() => NexT.utils.getScript(`${CONFIG.isso}js/embed.min.js`, {
+    .then(() => NexT.utils.getScript(`${CONFIG.isso.url}js/embed.min.js`, {
       attributes: {
         dataset: {
-          isso: `${CONFIG.isso}`
+          isso: `${CONFIG.isso.url}`,
+          issoLang: `${CONFIG.isso.lang }`,
+          issoReplyToSelf: `${CONFIG.isso.reply_to_self }`,
+          issoRequireAuthor: `${CONFIG.isso.require_author }`,
+          issoRequireEmail: `${CONFIG.isso.require_email }`,
+          issoReplyNotifications: `${CONFIG.isso.reply_notifications}`,
+          issoMaxCommentsTop: `${CONFIG.isso.max_comments_top }`,
+          issoMaxCommentsNested: `${CONFIG.isso.max_comments_nested }`,
+          issoRevealOnClick: `${CONFIG.isso.reveal_on_click }`,
+          issoAvatar: `${CONFIG.isso.avatar }`,
+          issoAvatarBg: `${CONFIG.isso.avatar_bg }`,
+          issoAvatarFg: `${CONFIG.isso.avatar_fg }`,
+          issoVote: `${CONFIG.isso.vote }`,
+          issoVoteLevels: `${CONFIG.isso.vote_levels }`,
+          issoFeed: `${CONFIG.isso.feed }`
         }
       },
       parentNode: document.querySelector('#isso-thread')


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [ ] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Other... Please describe: Add isso client's configuation items, so we can set isso's property in next/_config.yml.

Fixes #

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue resolved: None.

## What is the new behavior?
<!-- Description about this pull, in several words -->
Nothing new.

- Link to demo site with this changes:
- Screenshots with this changes:

### How to use?

In NexT `_config.yml`:
```yml
isso: 
  url: # Your isso server domain
  lang: zh # Set language
  # Set to true when spam guard is configured with reply-to-self = true.
  reply_to_self: "false" 
  # Set to true when spam guard is configured with require-author = true.
  require_author: "false" 
  # Set to true when spam guard is configured with require-email = true.
  require_email: "false" 
  # Set to true when reply notifications is configured with reply-notifications = true.
  reply_notifications: "false" 
  # Number of top level (or nested) comments to show by default. If some comments are not shown, an “X Hidden” link is shown.
  # Set to “inf” to show all, or “0” to hide all.
  max_comments_top: "10"
  max_comments_nested: "5"
  # Number of comments to reveal on clicking the “X Hidden” link.
  reveal_on_click: "5"
  # Enable or disable avatar generation.
  avatar: "true"
  # Set avatar background color. Any valid CSS color will do.
  avatar_bg: "#f0f0f0"
  # Set avatar foreground color. Up to 8 colors are possible. 
  # The default color scheme is based in this color palette. 
  # Multiple colors must be separated by space. 
  # If you use less than eight colors and not a multiple of 2, the color distribution is not even.
  avatar_fg: "#9abf88 #5698c4 #e279a3 #9163b6 ..."
  # Enable or disable voting feature on the client side.
  vote: "true"
  # List of vote levels used to customize comment appearance based on score. 
  # Provide a comma-separated values (eg. “0,5,10,25,100”) or a JSON array (eg. “[-5,5,15]”).
  vote_levels: ""
  # Enable or disable the addition of a link to the feed for the comment thread. 
  # The link will only be valid if the appropriate setting, in [rss] section, is also enabled server-side.
  feed: "false"
```
