### PR TITLE
Escape only `<` in front-end json

### DIFF
--- a/scripts/helpers/engine.js
+++ b/scripts/helpers/engine.js
@@ -43,7 +43,7 @@ hexo.extend.helper.register('next_vendors', function(name) {
 hexo.extend.helper.register('next_data', function(name, ...data) {
   const json = data.length === 1 ? data[0] : Object.assign({}, ...data);
   return `<script class="next-config" data-name="${name}" type="application/json">${
-    JSON.stringify(json)
+    JSON.stringify(json).replace(/</g, '\\u003c')
   }</script>`;
 });
 

--- a/scripts/helpers/engine.js
+++ b/scripts/helpers/engine.js
@@ -41,10 +41,9 @@ hexo.extend.helper.register('next_vendors', function(name) {
 });
 
 hexo.extend.helper.register('next_data', function(name, ...data) {
-  const { escape_html } = this;
   const json = data.length === 1 ? data[0] : Object.assign({}, ...data);
   return `<script class="next-config" data-name="${name}" type="application/json">${
-    escape_html(JSON.stringify(json))
+    JSON.stringify(json)
   }</script>`;
 });
 

--- a/source/js/config.js
+++ b/source/js/config.js
@@ -6,12 +6,7 @@ if (!window.NexT) window.NexT = {};
   const staticConfig = {};
   let variableConfig = {};
 
-  const parse = text => {
-    const jsonString = new DOMParser()
-      .parseFromString(text, 'text/html').documentElement
-      .textContent;
-    return JSON.parse(jsonString || '{}');
-  };
+  const parse = text => JSON.parse(text || '{}');
 
   const update = name => {
     const targetEle = document.querySelector(`.${className}[data-name="${name}"]`);


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [ ] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [x] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue resolved: #284 

## What is the new behavior?
<!-- Description about this pull, in several words -->

- Link to demo site with this changes:
- Screenshots with this changes:

### How to use?

In NexT `_config.yml`:
```yml

```
