### PR TITLE
Separate inline listeners

### DIFF
--- a/layout/_partials/post/post-reward.njk
+++ b/layout/_partials/post/post-reward.njk
@@ -1,6 +1,6 @@
 <div class="reward-container">
   <div>{{ page.reward_settings.comment }}</div>
-  <button onclick="document.querySelector('.post-reward').classList.toggle('active');">
+  <button>
     {{ __('reward.donate') }}
   </button>
   <div class="post-reward">

--- a/layout/_partials/sidebar/site-overview.njk
+++ b/layout/_partials/sidebar/site-overview.njk
@@ -62,10 +62,8 @@
 
 {%- if theme.chat.enable and (theme.chatra.enable or theme.tidio.enable or theme.gitter.enable) %}
   <div class="sidebar-button site-overview-item animated">
-  {%- if theme.chatra.enable %}
-    <button onclick="Chatra('openChat', true);">
-  {%- elif theme.tidio.enable %}
-    <button onclick="tidioChatApi.open();">
+  {%- if theme.chatra.enable or theme.tidio.enable %}
+    <button>
   {%- elif theme.gitter.enable %}
     <button class="js-gitter-toggle-chat-button">
   {%- endif %}

--- a/layout/_third-party/chat/tidio.njk
+++ b/layout/_third-party/chat/tidio.njk
@@ -1,1 +1,2 @@
 <script src="//code.tidio.co/{{ theme.tidio.key }}.js"></script>
+{{ next_js('third-party/chat/tidio.js') }}

--- a/source/js/next-boot.js
+++ b/source/js/next-boot.js
@@ -76,6 +76,7 @@ NexT.boot.refresh = function() {
   NexT.utils.registerActiveMenuItem();
   NexT.utils.registerLangSelect();
   NexT.utils.registerSidebarTOC();
+  NexT.utils.registerPostReward();
   NexT.utils.wrapTableWithBox();
   NexT.utils.registerVideoIframe();
 };

--- a/source/js/third-party/chat/chatra.js
+++ b/source/js/third-party/chat/chatra.js
@@ -1,10 +1,19 @@
-/* global CONFIG */
+/* global CONFIG, Chatra */
 
-if (CONFIG.chatra.embed) {
-  window.ChatraSetup = {
-    mode    : 'frame',
-    injectTo: CONFIG.chatra.embed
-  };
-}
+(function() {
+  if (CONFIG.chatra.embed) {
+    window.ChatraSetup = {
+      mode    : 'frame',
+      injectTo: CONFIG.chatra.embed
+    };
+  }
 
-window.ChatraID = CONFIG.chatra.id;
+  window.ChatraID = CONFIG.chatra.id;
+
+  const chatButton = document.querySelector('.sidebar-button button');
+  if (chatButton) {
+    chatButton.addEventListener('click', () => {
+      Chatra('openChat', true);
+    });
+  }
+})();

--- a/source/js/third-party/chat/tidio.js
+++ b/source/js/third-party/chat/tidio.js
@@ -1,0 +1,10 @@
+/* global tidioChatApi */
+
+(function() {
+  const chatButton = document.querySelector('.sidebar-button button');
+  if (chatButton) {
+    chatButton.addEventListener('click', () => {
+      tidioChatApi.open();
+    });
+  }
+})();

--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -282,6 +282,14 @@ NexT.utils = {
     });
   },
 
+  registerPostReward: function() {
+    const button = document.querySelector('.reward-container button');
+    if (!button) return;
+    button.addEventListener('click', () => {
+      document.querySelector('.post-reward').classList.toggle('active');
+    });
+  },
+
   activateNavByIndex: function(index) {
     const target = document.querySelectorAll('.post-toc li a.nav-link')[index];
     if (!target || target.classList.contains('active-current')) return;


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [ ] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [x] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->
Some `onclick` attributes are used, violating the no-unsafe-inline CSP rule.

Issue resolved:

## What is the new behavior?
<!-- Description about this pull, in several words -->
Seperate them into their homes.

P.S. In the next couple months, I prefer to further decoupling the third party stuff from the `utils.js`, `next-boot.js`, `site-overview.njk` etc., possibly by moving from `NexT.boot.refresh` to `page:ready` event, introducing new inject point(s), ...
Current NexT looks quite heavy for its high coupling level. Will open a discussion or something similar when I am free.

- Link to demo site with this changes:
- Screenshots with this changes:

### How to use?

In NexT `_config.yml`:
```yml

```
