### PR TITLE
Correct scroll offset

### DIFF
--- a/source/css/_common/components/post/post-body.styl
+++ b/source/css/_common/components/post/post-body.styl
@@ -15,8 +15,6 @@
   }
 
   h1, h2, h3, h4, h5, h6 {
-    padding-top: 10px;
-
     // Supported plugins: hexo-renderer-markdown-it hexo-renderer-marked
     .header-anchor, .headerlink {
       border-bottom-style: none;

--- a/source/css/_common/outline/mobile.styl
+++ b/source/css/_common/outline/mobile.styl
@@ -27,7 +27,7 @@
   .post-body {
     // For headers narrow width.
     h1, h2, h3, h4, h5, h6 {
-      margin: 10px 0 8px;
+      margin: 20px 0 8px;
     }
 
     // Rewrite paddings & margins inside tags.

--- a/source/css/_common/scaffolding/base.styl
+++ b/source/css/_common/scaffolding/base.styl
@@ -34,7 +34,7 @@ h1, h2, h3, h4, h5, h6 {
   font-family: $font-family-headings;
   font-weight: bold;
   line-height: 1.5;
-  margin: 20px 0 15px;
+  margin: 30px 0 15px;
 }
 
 for $headline in (1 .. 6) {

--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -181,7 +181,7 @@ NexT.utils = {
       }
       if (!Array.isArray(NexT.utils.sections)) return;
       let index = NexT.utils.sections.findIndex(element => {
-        return element && element.getBoundingClientRect().top > 0;
+        return element && element.getBoundingClientRect().top > 10;
       });
       if (index === -1) {
         index = NexT.utils.sections.length - 1;
@@ -275,7 +275,7 @@ NexT.utils = {
           targets  : document.scrollingElement,
           duration : 500,
           easing   : 'linear',
-          scrollTop: offset + 10,
+          scrollTop: offset,
           complete : () => {
             history.pushState(null, document.title, element.href);
           }


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [x] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->
1. Scroll to 10 px below the target title when clicking a site nav item. This is not the same behavior as clicking the anchor.
2. The condition to activate a nav item seems a bit strict, as it requires the target to already have some part above the screen.

Issue resolved:

## What is the new behavior?
<!-- Description about this pull, in several words -->
1. Scroll to the exact position when clicking a site nav item.
2. Activate the nav item when its target are <=10 px to the screen top.

- Link to demo site with this changes:
- Screenshots with this changes:

### How to use?

In NexT `_config.yml`:
```yml

```
