### PR TITLE
Calculate `--sidebar-wrapper-height` in pure CSS

### DIFF
--- a/layout/_macro/sidebar.njk
+++ b/layout/_macro/sidebar.njk
@@ -32,11 +32,9 @@
         <!--/noindex-->
 
         <div class="site-overview-wrap sidebar-panel">
-          <div class="site-overview">
-            {{ partial('_partials/sidebar/site-overview.njk', {}, {cache: theme.cache.enable}) }}
+          {{ partial('_partials/sidebar/site-overview.njk', {}, {cache: theme.cache.enable}) }}
 
-            {{- next_inject('sidebar') }}
-          </div>
+          {{- next_inject('sidebar') }}
         </div>
       </div>
 

--- a/source/css/_common/outline/sidebar/index.styl
+++ b/source/css/_common/outline/sidebar/index.styl
@@ -1,11 +1,10 @@
 .sidebar-inner {
   color: $grey-dark;
+  // Init Sidebar & TOC inner dimensions on all pages and for all schemes.
+  max-height: 'calc(100vh - %s)' % unit($sidebar-padding * 2, 'px');
   padding: $sidebar-padding 10px;
   text-align: center;
-}
-
-.site-overview {
-  max-height: var(--sidebar-wrapper-height);
+  flex-column();
 }
 
 .site-overview-item:not(:first-child) {

--- a/source/css/_common/outline/sidebar/index.styl
+++ b/source/css/_common/outline/sidebar/index.styl
@@ -1,7 +1,8 @@
 .sidebar-inner {
   color: $grey-dark;
   // Init Sidebar & TOC inner dimensions on all pages and for all schemes.
-  max-height: 'calc(100vh - %s)' % unit($sidebar-padding * 2, 'px');
+  $offset = (($scheme == 'Pisces') or ($scheme == 'Gemini')) ? $sidebar-offset : $sidebar-padding;
+  max-height: 'calc(100vh - %s)' % unit($offset * 2, 'px');
   padding: $sidebar-padding 10px;
   text-align: center;
   flex-column();

--- a/source/css/_common/outline/sidebar/sidebar-nav.styl
+++ b/source/css/_common/outline/sidebar/sidebar-nav.styl
@@ -35,8 +35,9 @@
   }
 }
 
+// Need for Sidebar/TOC inner scrolling if content taller then viewport.
 .sidebar-panel-container {
-  max-height: var(--sidebar-wrapper-height);
+  flex: 1;
   overflow-x: hidden;
   overflow-y: auto;
 }

--- a/source/js/next-boot.js
+++ b/source/js/next-boot.js
@@ -45,8 +45,6 @@ NexT.boot.registerEvents = function() {
     });
   });
 
-  window.addEventListener('resize', NexT.utils.initSidebarDimension);
-
   window.addEventListener('hashchange', () => {
     const tHash = location.hash;
     if (tHash !== '' && !tHash.match(/%\S{2}/)) {

--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -319,25 +319,7 @@ NexT.utils = {
     });
   },
 
-  /**
-   * Init Sidebar & TOC inner dimensions on all pages and for all schemes.
-   * Need for Sidebar/TOC inner scrolling if content taller then viewport.
-   */
-  initSidebarDimension: function() {
-    const sidebarNav = document.querySelector('.sidebar-nav');
-    const sidebarb2t = document.querySelector('.sidebar-inner .back-to-top');
-    const sidebarNavHeight = sidebarNav ? sidebarNav.offsetHeight : 0;
-    const sidebarb2tHeight = sidebarb2t ? sidebarb2t.offsetHeight : 0;
-    const sidebarOffset = CONFIG.sidebar.offset || 12;
-    let sidebarSchemePadding = (CONFIG.sidebar.padding * 2) + sidebarNavHeight + sidebarb2tHeight;
-    if (CONFIG.scheme === 'Pisces' || CONFIG.scheme === 'Gemini') sidebarSchemePadding += sidebarOffset * 2;
-    // Initialize Sidebar & TOC Height.
-    const sidebarWrapperHeight = document.body.offsetHeight - sidebarSchemePadding + 'px';
-    document.documentElement.style.setProperty('--sidebar-wrapper-height', sidebarWrapperHeight);
-  },
-
   updateSidebarPosition: function() {
-    NexT.utils.initSidebarDimension();
     if (window.innerWidth < 992 || CONFIG.scheme === 'Pisces' || CONFIG.scheme === 'Gemini') return;
     // Expand sidebar on post detail page by default, when post has a toc.
     const hasTOC = document.querySelector('.post-toc');

--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -311,6 +311,7 @@ NexT.utils = {
     }
     // Scrolling to center active TOC element if TOC content is taller then viewport.
     const tocElement = document.querySelector('.sidebar-panel-container');
+    if (!tocElement.parentNode.classList.contains('sidebar-toc-active')) return;
     window.anime({
       targets  : tocElement,
       duration : 200,


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [x] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue resolved:

See also https://github.com/next-theme/hexo-theme-next/pull/243

## What is the new behavior?
<!-- Description about this pull, in several words -->

- Link to demo site with this changes:
- Screenshots with this changes:

Refactor `sidebar-inner` with flex layout. Completely remove the `initSidebarDimension` function and `--sidebar-wrapper-height`

### How to use?

In NexT `_config.yml`:
```yml

```
