### PR TITLE
Perf: Use CDN to accelerate the speed of loading search.xml or search.json

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -739,6 +739,11 @@ local_search:
   unescape: false
   # Preload the search data when the page loads.
   preload: false
+  # Use CDN to accelerate the speed of loading search.xml or search.json
+  cdn:
+    enable: false
+    # url: //cdn.jsdelivr.net/gh/<username>/<username>.github.io/search.xml
+    url:
 
 
 # ---------------------------------------------------------------

--- a/source/js/third-party/search/local-search.js
+++ b/source/js/third-party/search/local-search.js
@@ -6,6 +6,12 @@ document.addEventListener('DOMContentLoaded', () => {
     console.warn('`hexo-generator-searchdb` plugin is not installed!');
     return;
   }
+
+  // Use CDN to accelerate the speed of loading search.xml or search.json
+  if ('cdn' in CONFIG.localsearch && CONFIG.localsearch.cdn.enable === true && CONFIG.localsearch.cdn.url !== null){
+    CONFIG.path = CONFIG.localsearch.cdn.url;
+  }
+
   // Popup Window
   let isfetched = false;
   let datas;


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [x] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->  

[https://github.com/next-theme/theme-next-docs/pull/47](https://github.com/next-theme/theme-next-docs/pull/47)

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->
Currently, the next theme loads the search.xml file from the source station.   
As the number of articles grows, so does the search.xml file size. Then the loading speed will decrease. If the waiting time exceeds 5 seconds, most people will lose patience. This is a bad experience.  

Issue resolved: N/A

## What is the new behavior?
<!-- Description about this pull, in several words -->
In my change, the next theme loads the search.xml file from CDN rather than github pages.   
The theme users can config the CDN url for search.xml freely in `_config.yml`.  
According to my experience, as I use the jdDelivr CDN, the search.xml file loading time is reduced to one-third of the original.   

- Screenshots with this changes:  N/A
- Link to demo site with this changes:  [好好学习的郝](https://www.voidking.com/)  

### How to use?

In NexT `_config.yml`:
```yml
# Local Search
# Dependencies: https://github.com/theme-next/hexo-generator-searchdb
local_search:
  enable: true
  # If auto, trigger search by changing input.
  # If manual, trigger search by pressing enter key or search button.
  trigger: auto
  # Show top n results per article, show all results by setting to -1
  top_n_per_article: 1
  # Unescape html strings to the readable one.
  unescape: false
  # Preload the search data when the page loads.
  preload: false
  # Use CDN to accelerate the speed of loading search.xml
  cdn:
    enable: true
    url: //cdn.jsdelivr.net/gh/<username>/<username>.github.io/search.xml
```

- `<username>` should be changed to your username in github.
- The `local_search.cdn.url` could be changed to any CDN url for search.xml . So,  whether you use github pages or not, you can speed up the file loading speed by configuring your own CDN.
