### PR TITLE
Add color-scheme CSS property

### DIFF
--- a/source/css/_colors.styl
+++ b/source/css/_colors.styl
@@ -24,6 +24,8 @@
   --highlight-foreground: $highlight-foreground;
   --highlight-gutter-background: $highlight-gutter-background;
   --highlight-gutter-foreground: $highlight-gutter-foreground;
+
+  color-scheme: light;
 }
 
 if (hexo-config('darkmode')) {
@@ -54,6 +56,8 @@ if (hexo-config('darkmode')) {
       --highlight-foreground: $highlight-foreground-dark;
       --highlight-gutter-background: $highlight-gutter-background-dark;
       --highlight-gutter-foreground: $highlight-gutter-foreground-dark;
+
+      color-scheme: dark;
     }
 
     img {
@@ -62,6 +66,10 @@ if (hexo-config('darkmode')) {
       &:hover {
         opacity: .9;
       }
+    }
+
+    iframe {
+      color-scheme: light;
     }
   }
 }


### PR DESCRIPTION
## PR Checklist 

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [x] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).

## PR Type

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?

![](https://user-images.githubusercontent.com/47095648/136956187-807dde05-b71b-401f-b051-35f1aeb579b0.png)

## What is the new behavior?

![](https://user-images.githubusercontent.com/47095648/136956374-4b3c94b6-0773-4f84-9b13-595f13d76e67.png)

The operating system makes adjustments to the user interface when set a `color-scheme` value. For example, the scroll bar is adapted to the dark mode when ser `color-scheme` to `dark`.

## References

<https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme>
