### PR TITLE
Add darkmode of DisqusJS

### DIFF
--- a/source/css/_common/components/third-party/disqusjs.styl
+++ b/source/css/_common/components/third-party/disqusjs.styl
@@ -1,0 +1,39 @@
+if (hexo-config('disqusjs.enable') and hexo-config('darkmode')) {
+  @media (prefers-color-scheme:dark) {
+      html #dsqjs a {
+          color: var(--link-color)
+      }
+
+      html #dsqjs a:focus,html #dsqjs a:hover {
+          color: var(--link-hover-color)
+      }
+
+      html #dsqjs .dsqjs-nav,html #dsqjs footer {
+          border-color: var(--card-bg-color)
+      }
+
+      html #dsqjs .dsqjs-load-more,html #dsqjs .dsqjs-load-more:hover,html #dsqjs .dsqjs-nav-tab,html #dsqjs .dsqjs-no-comment,html #dsqjs .dsqjs-post-content {
+          color: var(--text-color)
+      }
+
+      html #dsqjs .dsqjs-order-label {
+          background-color: #3e4b5e
+      }
+
+      html #dsqjs .dsqjs-order-radio:checked+.dsqjs-order-label {
+          background-color: var(--content-bg-color)
+      }
+
+      html #dsqjs .dsqjs-tab-active>span:after {
+          background-color: #2e9fff!important
+      }
+
+      html #dsqjs .dsqjs-footer,html #dsqjs .dsqjs-meta {
+          color: var(--text-color)
+      }
+
+      html #dsqjs .dsqjs-post-body blockquote {
+          border-color: var(--content-bg-color)
+      }
+  }
+}

--- a/source/css/_common/components/third-party/disqusjs.styl
+++ b/source/css/_common/components/third-party/disqusjs.styl
@@ -1,39 +1,39 @@
 if (hexo-config('disqusjs.enable') and hexo-config('darkmode')) {
   @media (prefers-color-scheme:dark) {
-      html #dsqjs a {
-          color: var(--link-color)
-      }
+    html #dsqjs a {
+      color: var(--link-color)
+    }
 
-      html #dsqjs a:focus,html #dsqjs a:hover {
-          color: var(--link-hover-color)
-      }
+    html #dsqjs a:focus,html #dsqjs a:hover {
+      color: var(--link-hover-color)
+    }
 
-      html #dsqjs .dsqjs-nav,html #dsqjs footer {
-          border-color: var(--card-bg-color)
-      }
+    html #dsqjs .dsqjs-nav,html #dsqjs footer {
+      border-color: var(--card-bg-color)
+    }
 
-      html #dsqjs .dsqjs-load-more,html #dsqjs .dsqjs-load-more:hover,html #dsqjs .dsqjs-nav-tab,html #dsqjs .dsqjs-no-comment,html #dsqjs .dsqjs-post-content {
-          color: var(--text-color)
-      }
+    html #dsqjs .dsqjs-load-more,html #dsqjs .dsqjs-load-more:hover,html #dsqjs .dsqjs-nav-tab,html #dsqjs .dsqjs-no-comment,html #dsqjs .dsqjs-post-content {
+      color: var(--text-color)
+    }
 
-      html #dsqjs .dsqjs-order-label {
-          background-color: #3e4b5e
-      }
+    html #dsqjs .dsqjs-order-label {
+      background-color: #3e4b5e
+    }
 
-      html #dsqjs .dsqjs-order-radio:checked+.dsqjs-order-label {
-          background-color: var(--content-bg-color)
-      }
+    html #dsqjs .dsqjs-order-radio:checked+.dsqjs-order-label {
+      background-color: var(--content-bg-color)
+    }
 
-      html #dsqjs .dsqjs-tab-active>span:after {
-          background-color: #2e9fff!important
-      }
+    html #dsqjs .dsqjs-tab-active>span:after {
+      background-color: #2e9fff!important
+    }
 
-      html #dsqjs .dsqjs-footer,html #dsqjs .dsqjs-meta {
-          color: var(--text-color)
-      }
+    html #dsqjs .dsqjs-footer,html #dsqjs .dsqjs-meta {
+      color: var(--text-color)
+    }
 
-      html #dsqjs .dsqjs-post-body blockquote {
-          border-color: var(--content-bg-color)
-      }
+    html #dsqjs .dsqjs-post-body blockquote {
+      border-color: var(--content-bg-color)
+    }
   }
 }

--- a/source/css/_common/components/third-party/index.styl
+++ b/source/css/_common/components/third-party/index.styl
@@ -1,3 +1,4 @@
+@import 'disqusjs';
 @import 'gitalk';
 @import 'utterances';
 @import 'search';


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue resolved: #141 

## What is the new behavior?
<!-- Description about this pull, in several words -->

- Link to demo site with this changes: None
- Screenshots with this changes:
![image](https://user-images.githubusercontent.com/46277145/142210966-06c7e225-2479-4c63-b513-66081daa22b3.png)

