### PR TITLE
Fix copy button position

### DIFF
--- a/source/css/_common/scaffolding/highlight/copy-code.styl
+++ b/source/css/_common/scaffolding/highlight/copy-code.styl
@@ -1,5 +1,12 @@
-.highlight:hover .copy-btn, pre:hover .copy-btn {
+.highlight:hover .copy-btn {
   opacity: 1;
+}
+
+.code-wrapper {
+  position: relative;
+  &:hover .copy-btn {
+    opacity: 1;
+  }
 }
 
 .copy-btn {

--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -52,8 +52,19 @@ NexT.utils = {
         });
       });
       if (!CONFIG.copycode) return;
-      element.insertAdjacentHTML('beforeend', '<div class="copy-btn"><i class="fa fa-copy fa-fw"></i></div>');
-      const button = element.querySelector('.copy-btn');
+
+      let button = null;
+      if (CONFIG.prism) {
+        var wrapper = document.createElement('div');
+        wrapper.classList.add('code-wrapper');
+        element.parentNode.insertBefore(wrapper, element);
+        wrapper.appendChild(element);
+        wrapper.insertAdjacentHTML('beforeend', '<div class="copy-btn"><i class="fa fa-copy fa-fw"></i></div>');
+        button = wrapper.querySelector('.copy-btn');
+      } else {
+        element.insertAdjacentHTML('beforeend', '<div class="copy-btn"><i class="fa fa-copy fa-fw"></i></div>');
+        button = element.querySelector('.copy-btn');
+      }
       button.addEventListener('click', () => {
         const lines = element.querySelector('.code') || element.querySelector('code');
         const code = lines.innerText;


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->
Code block's copy button doesn't position correctly when using prismjs
![image](https://user-images.githubusercontent.com/15013685/149630769-1144ce81-f98c-401d-a056-18525dcc346f.png)

Issue resolved: #98

## What is the new behavior?
<!-- Description about this pull, in several words -->
When using prismjs to highlight code, wrap a `<div>` to fix code button wrong position.

- Screenshots with this changes:
  - using prismjs:
    <img width="829" alt="prismjs" src="https://user-images.githubusercontent.com/15013685/149630554-e4188c29-530c-48f1-8360-6e13f1b9af67.png">
  - no effect on using highlightjs:
    <img width="828" alt="highlightjs" src="https://user-images.githubusercontent.com/15013685/149630558-ccfe7ce9-b4c3-45bd-bb18-a8d721ca6728.png">
