### PR TITLE
Fix preconnect config for venders with custom cdn

### DIFF
--- a/scripts/helpers/engine.js
+++ b/scripts/helpers/engine.js
@@ -62,7 +62,7 @@ hexo.extend.helper.register('next_pre', function() {
     jsdelivr: 'https://cdn.jsdelivr.net',
     unpkg   : 'https://unpkg.com',
     cdnjs   : 'https://cdnjs.cloudflare.com',
-    custom  : parse(custom_cdn_url || '').protocol + parse(custom_cdn_url || '').hostname
+    custom  : parse(custom_cdn_url || '').protocol + '//' + parse(custom_cdn_url || '').hostname
   };
   const h = enable ? host || 'https://fonts.googleapis.com' : '';
   const i = links[internal];

--- a/scripts/helpers/engine.js
+++ b/scripts/helpers/engine.js
@@ -58,7 +58,7 @@ hexo.extend.helper.register('next_pre', function() {
   const { enable, host } = this.theme.font;
   const { internal, plugins, custom_cdn_url } = this.theme.vendors;
   const links = {
-    local   : parse(this.theme.js || '').hostname,
+    local   : parse(this.theme.js || '').protocol + '//' + parse(this.theme.js || '').hostname,
     jsdelivr: 'https://cdn.jsdelivr.net',
     unpkg   : 'https://unpkg.com',
     cdnjs   : 'https://cdnjs.cloudflare.com',

--- a/scripts/helpers/engine.js
+++ b/scripts/helpers/engine.js
@@ -62,7 +62,7 @@ hexo.extend.helper.register('next_pre', function() {
     jsdelivr: 'https://cdn.jsdelivr.net',
     unpkg   : 'https://unpkg.com',
     cdnjs   : 'https://cdnjs.cloudflare.com',
-    custom  : parse(custom_cdn_url || '').hostname
+    custom  : parse(custom_cdn_url || '').protocol + parse(custom_cdn_url || '').hostname
   };
   const h = enable ? host || 'https://fonts.googleapis.com' : '';
   const i = links[internal];


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

If we set `venders.custom_cdn_url: https://lib.baomitu.com/${cdnjs_name}/${version}/${cdnjs_file}`, the `preconnect` in head will be `<link rel="preconnect" href="lib.baomitu.com" crossorigin="">`

And in Safari, the console shows `Successfully preconnected to https://pinlyu.com/lib.baomitu.com`

See: https://pinlyu.com

## What is the new behavior?
<!-- Description about this pull, in several words -->

- For HTTPS CDN

If we set `venders.custom_cdn_url: https://lib.baomitu.com/${cdnjs_name}/${version}/${cdnjs_file}`, the `preconnect` in head will be `<link rel="preconnect" href="https://lib.baomitu.com" crossorigin="">`

And in Safari, the console will show `Successfully preconnected to https://lib.baomitu.com/`

- For HTTP CDN

If we set `venders.custom_cdn_url: http://lib.baomitu.com/${cdnjs_name}/${version}/${cdnjs_file}`, the `preconnect` in head will be `<link rel="preconnect" href="http://lib.baomitu.com" crossorigin="">`

And in Safari, the console will show `Successfully preconnected to http://lib.baomitu.com/`

