### PR TITLE
Optimize the position of copy-button

### DIFF
--- a/scripts/helpers/next-config.js
+++ b/scripts/helpers/next-config.js
@@ -18,7 +18,7 @@ hexo.extend.helper.register('next_config', function() {
     version   : this.next_version,
     exturl    : theme.exturl,
     sidebar   : theme.sidebar,
-    copycode  : theme.codeblock.copy_button.enable,
+    copycode  : theme.codeblock.copy_button,
     bookmark  : theme.bookmark,
     mediumzoom: theme.mediumzoom,
     lazyload  : theme.lazyload,

--- a/source/css/_common/scaffolding/highlight/copy-code.styl
+++ b/source/css/_common/scaffolding/highlight/copy-code.styl
@@ -2,6 +2,12 @@
   opacity: 1;
 }
 
+figure.highlight {
+  .table-container {
+    position: relative;
+  }
+}
+
 .copy-btn {
   color: $black-dim;
   cursor: pointer;

--- a/source/js/next-boot.js
+++ b/source/js/next-boot.js
@@ -45,13 +45,13 @@ NexT.boot.refresh = function() {
   CONFIG.pangu && window.pangu.spacingPage();
 
   CONFIG.exturl && NexT.utils.registerExtURL();
+  NexT.utils.wrapTableWithBox();
   NexT.utils.registerCopyCode();
   NexT.utils.registerTabsTag();
   NexT.utils.registerActiveMenuItem();
   NexT.utils.registerLangSelect();
   NexT.utils.registerSidebarTOC();
   NexT.utils.registerPostReward();
-  NexT.utils.wrapTableWithBox();
   NexT.utils.registerVideoIframe();
 };
 

--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -51,8 +51,10 @@ NexT.utils = {
           span.classList.replace(name, `hljs-${name}`);
         });
       });
-      if (!CONFIG.copycode) return;
-      element.insertAdjacentHTML('beforeend', '<div class="copy-btn"><i class="fa fa-copy fa-fw"></i></div>');
+      if (!CONFIG.copycode.enable) return;
+      let target = element;
+      if (CONFIG.copycode.style !== 'mac') target = element.querySelector('.table-container') || element;
+      target.insertAdjacentHTML('beforeend', '<div class="copy-btn"><i class="fa fa-copy fa-fw"></i></div>');
       const button = element.querySelector('.copy-btn');
       button.addEventListener('click', () => {
         const lines = element.querySelector('.code') || element.querySelector('code');


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue resolved:

<img width="426" alt="截屏2022-04-30 00 18 56" src="https://user-images.githubusercontent.com/16272760/165984017-ea6e8b5d-8528-465d-a0ae-9742620135a8.png">


## What is the new behavior?
<!-- Description about this pull, in several words -->

- Link to demo site with this changes:
- Screenshots with this changes:

### How to use?

In NexT `_config.yml`:
```yml

```
