### PR TITLE
Fix double quotes inside cloudflare analytics HTML attribute

### DIFF
--- a/layout/_third-party/analytics/cloudflare.njk
+++ b/layout/_third-party/analytics/cloudflare.njk
@@ -1,3 +1,3 @@
 {%- if theme.cloudflare_analytics %}
-  <script{{ pjax }} defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "{{ theme.cloudflare_analytics }}"}'></script>
+  <script{{ pjax }} defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{&quot;token&quot;: &quot;{{ theme.cloudflare_analytics }}&quot;}'></script>
 {%- endif %}


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [ ] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

I'm using hexo 6.2.0
The origin cloudflare.njk is rendered using single quote, like `data-cf-beacon='{"token": "xxx"}'`. 
But it's somehow replaced to double quote after `hexo g`, like `data-cf-beacon="{"token": "xxx"}"`, which causes cloudflare analytics malfunction.

## What is the new behavior?
<!-- Description about this pull, in several words -->

Now the double quote inside the attribute is replaced to the HTML entities, to get rid of the single quote replacement.

