### PR TITLE
Add matomo as an analytics provider

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -693,6 +693,13 @@ cloudflare_analytics:
 # See: https://clarity.microsoft.com/
 clarity_analytics: # <project_id>
 
+# Matomo Analytics
+# See: https://matomo.org/
+matomo:
+  enable: false
+  server_url: # https://www.example.com/
+  site_id: # <your site id>
+
 # Show number of visitors of each article.
 # You can visit https://www.leancloud.cn to get AppID and AppKey.
 leancloud_visitors:

--- a/layout/_third-party/analytics/index.njk
+++ b/layout/_third-party/analytics/index.njk
@@ -3,3 +3,4 @@
 {%- include 'growingio.njk' -%}
 {%- include 'cloudflare.njk' -%}
 {%- include 'microsoft-clarity.njk' -%}
+{%- include 'matomo.njk' -%}

--- a/layout/_third-party/analytics/matomo.njk
+++ b/layout/_third-party/analytics/matomo.njk
@@ -1,0 +1,4 @@
+{%- if theme.matomo.enable %}
+  {{ next_data('matomo', theme.matomo) }}
+  {{ next_js('third-party/analytics/matomo.js') }}
+{%- endif %}

--- a/source/js/third-party/analytics/matomo.js
+++ b/source/js/third-party/analytics/matomo.js
@@ -1,0 +1,19 @@
+/* global CONFIG */
+
+if (CONFIG.matomo.enable) {
+  window._paq = window._paq || [];
+  const _paq = window._paq;
+
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  const u = CONFIG.matomo.server_url;
+  _paq.push(['setTrackerUrl', u + 'matomo.php']);
+  _paq.push(['setSiteId', CONFIG.matomo.site_id]);
+  const d = document;
+  const g = d.createElement('script');
+  const s = d.getElementsByTagName('script')[0];
+  g.async = true;
+  g.src = u + 'matomo.js';
+  s.parentNode.insertBefore(g, s);
+}


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->
There's no support for Matomo Analytics
Issue resolved: None

## What is the new behavior?
<!-- Description about this pull, in several words -->
Simple change. It does work if you can see three http requests about matomo as shown below.
- Link to demo site with this changes: None
- Screenshots with this changes: 
![image](https://user-images.githubusercontent.com/87483042/182457271-b88cd660-bcdf-4640-9f42-5b17339f6115.png)

### How to use?

In NexT `_config.yml`, line 696:
```yml
# Matomo Analytics
# See: https://matomo.org/
matomo:
  enable: false
  server_url: # https://www.example.com/
  site_id: # <your site id>
```
## Notes
I haven't updated the docs and I will finish it after this PR being accepted. This is my first PR in my life, so please correct me if there is any mistake.