### PR TITLE
Integrated waline comment component.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -646,6 +646,32 @@ utterances:
 # For more information: https://posativ.org/isso/
 isso: # <data_isso>
 
+# Waline
+# For more information: https://waline.js.org
+waline:
+  enable: false
+  serverURL: # Waline backend servie url.
+  pageview: true # View count
+  comment: true # Comment count
+  lang: zh # I18n Support: zh | zh-CN | zh-TW | en | en-US | jp | jp-JP | pt-BR | ru | ru-RU
+  meta: [ nick, mail, link ] # Reviewer attributes. Optional values: 'nick', 'mail', 'link'
+  requiredMeta: [ mail ] # Set required fields, default anonymous, optional values []
+  metaPlaceholder:  # Set meta placeholder, config 'nick' and 'link' is the same as setting 'mail'.
+    mail: 'Get avator'
+  login: enable # Login mode status, optional values: enable, disable, force
+  wordLimit: 0 # Comment word s limit. When a single number is filled in, it 's the maximum number of comment words. No limit when set to 0.
+  pageSize: 10 # number of comments per page.
+  copyright: true
+  emojiCdn: # Optional: jsdelivr | unpkg (default)
+  emoji: # Optional: alus, bilibili, qq, tieba, twitter, weibo
+    - alus
+    - bilibili
+    - twitter
+    - weibo
+    #- https://example.com/myemoji.1  # how to creating own, see:
+    #- https://example.com/myemoji.2  # https://waline.js.org/en/guide/client/emoji.html#creating-own-preset
+    #- https://example.com/myemoji.n
+
 
 # ---------------------------------------------------------------
 # Post Widgets & Content Sharing Services

--- a/_vendors.yml
+++ b/_vendors.yml
@@ -172,3 +172,19 @@ creative_commons:
   version: 2020.11.3
   dir: assets/license_badges
   alias: creativecommons-vocabulary
+waline_js:
+  name: '@waline/client'
+  version: 2.6.2
+  file: dist/waline.js
+waline_js_cdnjs:
+  name: 'waline'
+  version: 2.6.2
+  file: waline.js
+waline_css:
+  name: '@waline/client'
+  version: 2.6.2
+  file: dist/waline.css
+waline_css_cdnjs:
+  name: 'waline'
+  version: 2.6.2
+  file: waline.css

--- a/languages/ar.yml
+++ b/languages/ar.yml
@@ -29,6 +29,7 @@ post:
   untitled: بدون عنوان
   sticky: مثبت
   views: مشاهدات
+  comments: تعليق
   related_posts: مقالات مشابهة
   copyright:
     author: مؤلف المقال

--- a/languages/bn.yml
+++ b/languages/bn.yml
@@ -29,6 +29,7 @@ post:
   untitled: শিরোনামহীন
   sticky: স্থির
   views: ভিউ
+  comments: মন্তব্য করুন
   related_posts: সম্পর্কিত পোস্ট
   copyright:
     author: লিখিকা

--- a/languages/de.yml
+++ b/languages/de.yml
@@ -29,6 +29,7 @@ post:
   untitled: Unbenannt
   sticky: Angepinnt
   views: Aufrufe
+  comments: Kommentar
   related_posts: Ähnliche Beiträge
   copyright:
     author: Beitragsautor

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -32,6 +32,7 @@ post:
   untitled: Untitled
   sticky: Sticky
   views: Views
+  comments: Comments
   related_posts: Related Posts
   copyright:
     author: Post author

--- a/languages/es.yml
+++ b/languages/es.yml
@@ -29,6 +29,7 @@ post:
   untitled: Sin título
   sticky: Destacados
   views: Visitas
+  comments: Comente
   related_posts: Entradas relacionadas
   copyright:
     author: Autor de la entrada

--- a/languages/fa.yml
+++ b/languages/fa.yml
@@ -29,6 +29,7 @@ post:
   untitled: بدون عنوان
   sticky: چسبنده
   views: بازدیدها
+  comments: اظهار نظر
   related_posts: پست های مرتبط
   copyright:
     author: نویسنده پست

--- a/languages/fr.yml
+++ b/languages/fr.yml
@@ -29,6 +29,7 @@ post:
   untitled: Sans titre
   sticky: Épingler
   views: Vues
+  comments: Commentaire
   related_posts: Articles similaires
   copyright:
     author: Auteur de l'article

--- a/languages/id.yml
+++ b/languages/id.yml
@@ -29,6 +29,7 @@ post:
   untitled: Tidak ada title
   sticky: Sticky
   views: Views
+  comments: Komentar
   related_posts: Related Posts
   copyright:
     author: Post author

--- a/languages/it.yml
+++ b/languages/it.yml
@@ -29,6 +29,7 @@ post:
   untitled: Senza titolo
   sticky: Sticky
   views: Views
+  comments: Commento
   related_posts: Related Posts
   copyright:
     author: Autore

--- a/languages/ja.yml
+++ b/languages/ja.yml
@@ -29,6 +29,7 @@ post:
   untitled: 無題
   sticky: 固定
   views: 閲覧数
+  comments: コメント
   related_posts: 関連記事
   copyright:
     author: 著者

--- a/languages/ko.yml
+++ b/languages/ko.yml
@@ -29,6 +29,7 @@ post:
   untitled: 제목 없음
   sticky: 고정
   views: Views
+  comments: 논평
   related_posts: Related Posts
   copyright:
     author: 포스트 작성자

--- a/languages/nl.yml
+++ b/languages/nl.yml
@@ -29,6 +29,7 @@ post:
   untitled: Naamloos
   sticky: Sticky
   views: Views
+  comments: Opmerking
   related_posts: Related Posts
   copyright:
     author: Post auteur

--- a/languages/pt-BR.yml
+++ b/languages/pt-BR.yml
@@ -29,6 +29,7 @@ post:
   untitled: Sem título
   sticky: Fixo
   views: Visualizações
+  comments: Comente
   related_posts: Publicações Relacionadas
   copyright:
     author: Autor da publicação

--- a/languages/pt.yml
+++ b/languages/pt.yml
@@ -29,6 +29,7 @@ post:
   untitled: Sem título
   sticky: Sticky
   views: Views
+  comments: Comente
   related_posts: Related Posts
   copyright:
     author: Post author

--- a/languages/ru.yml
+++ b/languages/ru.yml
@@ -29,6 +29,7 @@ post:
   untitled: Безимянный
   sticky: Ссылка
   views: Просмотров
+  comments: Комментарий
   related_posts: Похожие записи
   copyright:
     author: Автор записи

--- a/languages/si.yml
+++ b/languages/si.yml
@@ -29,6 +29,7 @@ post:
   untitled: නිර්නාමික
   sticky: ඇලෙන
   views: දර්ශන වාර
+  comments: අදහස් දක්වන්න
   related_posts: ආශ්‍රිත ලිපි
   copyright:
     author: කර්තෘ

--- a/languages/tk.yml
+++ b/languages/tk.yml
@@ -29,6 +29,7 @@ post:
   untitled: Atlandyrylmadyk
   sticky: Salgylanma
   views: Görüldi
+  comments: Düşündiriş
   related_posts: Meňzeş makalalar
   copyright:
     author: Makalanyň awtory

--- a/languages/tr.yml
+++ b/languages/tr.yml
@@ -29,6 +29,7 @@ post:
   untitled: Başlıksız
   sticky: Sabit
   views: Görünümler
+  comments: Yorum
   related_posts: İlgili Gönderiler
   copyright:
     author: Gönderiyi yazan

--- a/languages/uk.yml
+++ b/languages/uk.yml
@@ -29,6 +29,7 @@ post:
   untitled: Без імені
   sticky: Посилання
   views: Переглядів
+  comments: коментар
   related_posts: Схожі записи
   copyright:
     author: Автор запису

--- a/languages/vi.yml
+++ b/languages/vi.yml
@@ -29,6 +29,7 @@ post:
   untitled: Không có tiêu đề
   sticky: Đính
   views: Lượt xem
+  comments: Bình luận
   related_posts: Các bài viết liên quan
   copyright:
     author: Người viết

--- a/languages/zh-CN.yml
+++ b/languages/zh-CN.yml
@@ -29,6 +29,7 @@ post:
   untitled: 未命名
   sticky: 置顶
   views: 阅读次数
+  comments: 评论数
   related_posts: 相关文章
   copyright:
     author: 本文作者

--- a/languages/zh-HK.yml
+++ b/languages/zh-HK.yml
@@ -29,6 +29,7 @@ post:
   untitled: 未命名
   sticky: 置頂
   views: 閱讀次數
+  comments: 評論數
   related_posts: 相關文章
   copyright:
     author: 博主

--- a/languages/zh-TW.yml
+++ b/languages/zh-TW.yml
@@ -29,6 +29,7 @@ post:
   untitled: 未命名
   sticky: 置頂
   views: 閱讀次數
+  comments: 評論數
   related_posts: 相關文章
   copyright:
     author: 作者

--- a/layout/_partials/post/post-meta.njk
+++ b/layout/_partials/post/post-meta.njk
@@ -68,6 +68,32 @@
       <span class="firestore-visitors-count"></span>
     </span>
   {%- endif %}
+  
+  {# Waline PageView count #}
+  {%- if theme.waline.enable and theme.waline.pageview %}
+  <span class="post-meta-item" title="{{ __('post.views') }}">
+    <span class="post-meta-item-icon">
+        <i class="far fa-eye"></i>
+    </span>
+    <span class="post-meta-item-text">{{ __('post.views') }}
+      <i class="waline-pageview-count" data-path="{{ url_for(post.path) }}"></i>
+    </span>
+  </span>
+  {% endif %}
+
+  {# Waline Comment count #}
+  {%- if theme.waline.enable and theme.waline.comment %}
+  <span class="post-meta-item" title="{{ __('post.comments') }}">
+    <span class="post-meta-item-icon">
+        <i class="far fa-comments"></i>
+    </span>
+    <span class="post-meta-item-text">{{ __('post.comments') }}
+      <a href="{{ url_for(post.path) }}#waline">
+        <i class="waline-comment-count" data-path="{{ url_for(post.path) }}"></i>
+      </a>
+    </span>
+  </span>
+  {% endif %}
 
   {%- if not is_index and theme.busuanzi_count.enable and theme.busuanzi_count.post_views %}
     <span class="post-meta-item" title="{{ __('post.views') }}" id="busuanzi_container_page_pv">

--- a/layout/_third-party/comments/waline.njk
+++ b/layout/_third-party/comments/waline.njk
@@ -1,0 +1,9 @@
+{%- if theme.vendors.plugins == 'cdnjs' %}
+  {{ next_vendors('waline_css_cdnjs') }}
+  {{ next_data('waline', theme.waline, {js: theme.vendors.waline_js_cdnjs}) }}
+{%- else %}
+  {{ next_vendors('waline_css') }}
+  {{ next_data('waline', theme.waline, {js: theme.vendors.waline_js}) }}
+{%- endif %}
+
+{{ next_js('third-party/comments/waline.js') }}

--- a/scripts/filters/comment/waline.js
+++ b/scripts/filters/comment/waline.js
@@ -1,0 +1,16 @@
+/* global hexo */
+
+'use strict';
+
+const path = require('path');
+
+// Add comment
+hexo.extend.filter.register('theme_inject', injects => {
+  const theme = hexo.theme.config;
+  if (!theme.waline.enable) return;
+
+  injects.comment.raw('waline', '<div class="comments waline-container"><div id="waline"></div></div>', {}, { cache: true });
+
+  injects.bodyEnd.file('waline', path.join(hexo.theme_dir, 'layout/_third-party/comments/waline.njk'));
+
+});

--- a/scripts/filters/comment/waline.js
+++ b/scripts/filters/comment/waline.js
@@ -8,9 +8,7 @@ const path = require('path');
 hexo.extend.filter.register('theme_inject', injects => {
   const theme = hexo.theme.config;
   if (!theme.waline.enable) return;
-
-  injects.comment.raw('waline', '<div class="comments waline-container"><div id="waline"></div></div>', {}, { cache: true });
-
+  let html = '<div class="comments waline-container"><div id="waline"></div></div>';
+  injects.comment.raw('waline', html, {}, { cache: true });
   injects.bodyEnd.file('waline', path.join(hexo.theme_dir, 'layout/_third-party/comments/waline.njk'));
-
 });

--- a/source/js/third-party/comments/waline.js
+++ b/source/js/third-party/comments/waline.js
@@ -1,0 +1,146 @@
+/* global NexT, CONFIG, Waline */
+
+if (!CONFIG.waline.emojis) {
+  CONFIG.waline.emojis = [];
+}
+
+/**
+ * Set waline emojis sources.
+ */
+const emojis = CONFIG.waline.emojis;
+const vendor = CONFIG.waline.emojiCdn === 'jsdelivr' ?
+    'https://cdn.jsdelivr.net/npm' : 'https://unpkg.com';
+
+for (let item of CONFIG.waline.emoji) {
+  switch (item) {
+    case "alus":
+      emojis.push(`${vendor}/@waline/emojis@1.0.1/alus`);
+      break;
+    case "bilibili":
+      emojis.push(`${vendor}/@waline/emojis@1.0.1/bilibili`)
+      break;
+    case "qq":
+      emojis.push(`${vendor}/@waline/emojis@1.0.1/qq`)
+      break;
+    case "tieba":
+      emojis.push(`${vendor}/@waline/emojis@1.0.1/tieba`);
+      break;
+    case "twitter":
+      emojis.push(`${vendor}/@waline/emojis@1.0.1/tw-emoji`);
+      break;
+    case "weibo":
+      emojis.push(`${vendor}/@waline/emojis@1.0.1/weibo`);
+      break;
+    default:
+      emojis.push(item);
+  }
+}
+
+/**
+ * initialize waline.
+ */
+ const initWaline = () => {
+  if (Waline.instance) {
+    Waline.instance.destroy();
+  }
+  Waline.instance = Waline.init({
+    el: '#waline',
+    serverURL: CONFIG.waline.serverURL,
+    pageview: CONFIG.waline.pageview,
+    comment: CONFIG.waline.comment,
+    lang: CONFIG.waline.lang,
+    meta: CONFIG.waline.meta,
+    requiredMeta: CONFIG.waline.requiredMeta,
+    login: CONFIG.waline.login,
+    wordLimit: CONFIG.waline.wordLimit,
+    pageSize: CONFIG.waline.pageSize,
+    copyright: CONFIG.waline.copyright,
+    emoji: CONFIG.waline.emojis
+  });
+}
+
+/**
+ * refresh Waline
+ */
+const observeWaline = () => {
+
+  const waitToRun = (selector) => {
+    timeout = 30000,
+    start = Date.now();
+    return new Promise((resolve, reject) => {
+      let getElem = function () {
+        // check timeout.
+        if (Date.now() - start > timeout) {
+          reject(`Query element '${selector}' timeout, 30s.`)
+          return;
+        }
+        // query element
+        let elem = document.querySelector(selector);
+        if (elem) {
+          resolve(elem);
+          return;
+        }
+        setTimeout(getElem, 500);
+      }
+      getElem();
+    });
+  }
+
+  // Observe login button to reinitialize waline instance.
+  waitToRun(".wl-footer .wl-info").then(elem => {
+    options = { childList: true };
+
+    if (!Waline.observer) {
+      Waline.observer = new MutationObserver((mutationList) => {
+        let nodeAll = [];
+        mutationList.forEach(nodes => {
+          nodes.addedNodes.forEach(list => nodeAll = nodeAll.concat(list));
+          nodes.removedNodes.forEach(list => nodeAll = nodeAll.concat(list));
+        });
+        for (let node of nodeAll) {
+          if (node.nodeName != "BUTTON" || node.className != "wl-btn") {
+            continue;
+          }
+          initWaline();
+          observeWaline();
+          return;
+        }
+      });
+    }
+
+    Waline.observer.disconnect();
+    Waline.observer.observe(elem, options);
+  }).catch(reson => console.log(reson));
+
+  //Set input placeholder.
+  const metaPlaceholder = CONFIG.waline.metaPlaceholder;
+  if (!metaPlaceholder) {
+    return;
+  }
+  if (metaPlaceholder.nick) {
+    waitToRun('.wl-header-item input.wl-nick')
+    .then(elem => elem.placeholder = metaPlaceholder.nick)
+    .catch(reson => console.log(reson));
+  }
+  if (metaPlaceholder.mail) {
+    waitToRun('.wl-header-item input.wl-mail')
+    .then(elem => elem.placeholder = metaPlaceholder.mail)
+    .catch(reson => console.log(reson));
+  }
+  if (metaPlaceholder.link) {
+    waitToRun('.wl-header-item input.wl-link')
+    .then(elem => elem.placeholder = metaPlaceholder.link)
+    .catch(reson => console.log(reson));
+  }
+}
+
+document.addEventListener('page:loaded', () => {
+  if (!CONFIG.page.comments) return;
+
+  NexT.utils.loadComments('.waline-container')
+    .then(() => NexT.utils.getScript(CONFIG.waline.js, {
+      condition: window.Waline
+    }))
+    .then(initWaline)
+    .then(observeWaline);
+});


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [ x ] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [ x ] Tests for the changes was maked (for bug fixes / features).
   - [ x ] Muse | Mist have been tested.
   - [ x ] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [ x ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ x ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

The waline comment component is not supported.

## What is the new behavior?
<!-- Description about this pull, in several words -->

- Link to demo site with this changes:   
   <https://four2.site/more/visitor.html>
- Screenshots with this changes:   
  ![waline.png](https://www.png8.com/imgs/2022/08/11/320815bf23a0e205.png)

### How to use?

In NexT `_config.yml`, line 649:
```yml
# Waline
# For more information: https://waline.js.org
waline:
  enable: false
  serverURL: # Waline backend servie url.
  pageview: true # View count
  comment: true # Comment count
  lang: zh # I18n Support: zh | zh-CN | zh-TW | en | en-US | jp | jp-JP | pt-BR | ru | ru-RU
  meta: [ nick, mail, link ] # Reviewer attributes. Optional values: 'nick', 'mail', 'link'
  requiredMeta: [ mail ] # Set required fields, default anonymous, optional values []
  metaPlaceholder:  # Set meta placeholder, config 'nick' and 'link' is the same as setting 'mail'.
    mail: 'Get avator'
  login: enable # Login mode status, optional values: enable, disable, force
  wordLimit: 0 # Comment word s limit. When a single number is filled in, it 's the maximum number of comment words. No limit when set to 0.
  pageSize: 10 # number of comments per page.
  copyright: true
  emojiCdn: # Optional: jsdelivr | unpkg (default)
  emoji: # Optional: alus, bilibili, qq, tieba, twitter, weibo
    - alus
    - bilibili
    - twitter
    - weibo
    #- https://example.com/myemoji.1  # how to creating own, see:
    #- https://example.com/myemoji.2  # https://waline.js.org/en/guide/client/emoji.html#creating-own-preset
    #- https://example.com/myemoji.n
```
