### PR TITLE
Add transition animation for the height of `tab-content` when tab switches

### DIFF
--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -172,19 +172,19 @@ NexT.utils = {
         if (element.classList.contains('active')) return;
         const nav = element.parentNode;
         // Get the height of `tab-pane` which is activated before, and set it as the height of `tab-content` with extra margin / paddings.
-        for (var i = 0; i < nav.children.length; i++) {
+        let i;
+        for (i = 0; i < nav.children.length; i++) {
           if (nav.children[i].classList.contains('active')) {
             break;
           }
         }
         const tabContent = nav.nextElementSibling;
         tabContent.style.overflow = 'hidden';
-        tabContent.style.transition = 'height 1s'
+        tabContent.style.transition = 'height 1s';
         const prevHeight = parseFloat(window.getComputedStyle(tabContent.children[i]).height.replace('px', ''));
         const paddingTop = parseFloat(window.getComputedStyle(tabContent.children[i]).paddingTop.replace('px', ''));
         const marginBottom = parseFloat(window.getComputedStyle(tabContent.children[i].firstChild).marginBottom.replace('px', ''));
         tabContent.style.height = prevHeight + paddingTop + marginBottom + 'px';
-        
         // Add & Remove active class on `nav-tabs` & `tab-content`.
         [...nav.children].forEach(target => {
           target.classList.toggle('active', target === element);
@@ -199,28 +199,29 @@ NexT.utils = {
           bubbles: true
         }));
         // Get the height of `tab-pane` which is activated now.
-        for (var j = 0; j < nav.children.length; j++) {
+        let j;
+        for (j = 0; j < nav.children.length; j++) {
           if (nav.children[j].classList.contains('active')) {
             break;
           }
         }
         const hasScrollBar = document.body.scrollHeight > (window.innerHeight || document.documentElement.clientHeight);
         const currHeight = parseFloat(window.getComputedStyle(tabContent.children[j]).height.replace('px', ''));
-        // Reset the height of `tab-content` and see the animation 
+        // Reset the height of `tab-content` and see the animation
         tabContent.style.height = currHeight + paddingTop + marginBottom + 'px';
-        // Change the height of `tab-content` may cause scrollbar show / disappear, which may result in the change of the `tab-pane`'s height 
-        setTimeout(function () {
-          if (document.body.scrollHeight > (window.innerHeight || document.documentElement.clientHeight) !== hasScrollBar){
+        // Change the height of `tab-content` may cause scrollbar show / disappear, which may result in the change of the `tab-pane`'s height
+        setTimeout(function() {
+          if ((document.body.scrollHeight > (window.innerHeight || document.documentElement.clientHeight)) !== hasScrollBar) {
             tabContent.style.transition = 'height 0.3s linear';
             // After the animation, we need reset the height of `tab-content` again.
             const currHeightAfterScrollBarChange = parseFloat(window.getComputedStyle(tabContent.children[j]).height.replace('px', ''));
             tabContent.style.height = currHeightAfterScrollBarChange + paddingTop + marginBottom + 'px';
           }
           // Remove all the inline styles, and let the height be adaptive again.
-          setTimeout(function () {
+          setTimeout(function() {
             tabContent.style.transition = '';
             tabContent.style.height = '';
-          }, 250)
+          }, 250);
         }, 1000);
         if (!CONFIG.stickytabs) return;
         const offset = nav.parentNode.getBoundingClientRect().top + window.scrollY + 10;

--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -198,7 +198,7 @@ NexT.utils = {
         // Reset the height of `tab-content` and see the animation.
         tabContent.style.height = currHeight + paddingTop + marginBottom + 'px';
         // Change the height of `tab-content` may cause scrollbar show / disappear, which may result in the change of the `tab-pane`'s height
-        setTimeout(function() {
+        setTimeout(() => {
           if ((document.body.scrollHeight > (window.innerHeight || document.documentElement.clientHeight)) !== hasScrollBar) {
             tabContent.style.transition = 'height 0.3s linear';
             // After the animation, we need reset the height of `tab-content` again.
@@ -206,7 +206,7 @@ NexT.utils = {
             tabContent.style.height = currHeightAfterScrollBarChange + paddingTop + marginBottom + 'px';
           }
           // Remove all the inline styles, and let the height be adaptive again.
-          setTimeout(function() {
+          setTimeout(() => {
             tabContent.style.transition = '';
             tabContent.style.height = '';
           }, 250);

--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -175,9 +175,9 @@ NexT.utils = {
         const tabContent = nav.nextElementSibling;
         tabContent.style.overflow = 'hidden';
         tabContent.style.transition = 'height 1s';
-        const prevHeight = parseInt(window.getComputedStyle(tabContent.querySelector('.active')).height.replace('px', ''));
-        const paddingTop = parseInt(window.getComputedStyle(tabContent.querySelector('.active')).paddingTop.replace('px', ''));
-        const marginBottom = parseInt(window.getComputedStyle(tabContent.querySelector('.active').firstChild).marginBottom.replace('px', ''));
+        const prevHeight = parseInt(window.getComputedStyle(tabContent.querySelector('.active')).height.replace('px', ''), 10);
+        const paddingTop = parseInt(window.getComputedStyle(tabContent.querySelector('.active')).paddingTop.replace('px', ''), 10);
+        const marginBottom = parseInt(window.getComputedStyle(tabContent.querySelector('.active').firstChild).marginBottom.replace('px', ''), 10);
         tabContent.style.height = prevHeight + paddingTop + marginBottom + 'px';
         // Add & Remove active class on `nav-tabs` & `tab-content`.
         [...nav.children].forEach(target => {
@@ -194,7 +194,7 @@ NexT.utils = {
         }));
         // Get the height of `tab-pane` which is activated now.
         const hasScrollBar = document.body.scrollHeight > (window.innerHeight || document.documentElement.clientHeight);
-        const currHeight = parseInt(window.getComputedStyle(tabContent.querySelector('.active')).height.replace('px', ''));
+        const currHeight = parseInt(window.getComputedStyle(tabContent.querySelector('.active')).height.replace('px', ''), 10);
         // Reset the height of `tab-content` and see the animation.
         tabContent.style.height = currHeight + paddingTop + marginBottom + 'px';
         // Change the height of `tab-content` may cause scrollbar show / disappear, which may result in the change of the `tab-pane`'s height
@@ -202,7 +202,7 @@ NexT.utils = {
           if ((document.body.scrollHeight > (window.innerHeight || document.documentElement.clientHeight)) !== hasScrollBar) {
             tabContent.style.transition = 'height 0.3s linear';
             // After the animation, we need reset the height of `tab-content` again.
-            const currHeightAfterScrollBarChange = parseInt(window.getComputedStyle(tabContent.querySelector('.active')).height.replace('px', ''));
+            const currHeightAfterScrollBarChange = parseInt(window.getComputedStyle(tabContent.querySelector('.active')).height.replace('px', ''), 10);
             tabContent.style.height = currHeightAfterScrollBarChange + paddingTop + marginBottom + 'px';
           }
           // Remove all the inline styles, and let the height be adaptive again.

--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -172,18 +172,12 @@ NexT.utils = {
         if (element.classList.contains('active')) return;
         const nav = element.parentNode;
         // Get the height of `tab-pane` which is activated before, and set it as the height of `tab-content` with extra margin / paddings.
-        let i;
-        for (i = 0; i < nav.children.length; i++) {
-          if (nav.children[i].classList.contains('active')) {
-            break;
-          }
-        }
         const tabContent = nav.nextElementSibling;
         tabContent.style.overflow = 'hidden';
         tabContent.style.transition = 'height 1s';
-        const prevHeight = parseFloat(window.getComputedStyle(tabContent.children[i]).height.replace('px', ''));
-        const paddingTop = parseFloat(window.getComputedStyle(tabContent.children[i]).paddingTop.replace('px', ''));
-        const marginBottom = parseFloat(window.getComputedStyle(tabContent.children[i].firstChild).marginBottom.replace('px', ''));
+        const prevHeight = parseFloat(window.getComputedStyle(tabContent.querySelector('.active')).height.replace('px', ''));
+        const paddingTop = parseFloat(window.getComputedStyle(tabContent.querySelector('.active')).paddingTop.replace('px', ''));
+        const marginBottom = parseFloat(window.getComputedStyle(tabContent.querySelector('.active').firstChild).marginBottom.replace('px', ''));
         tabContent.style.height = prevHeight + paddingTop + marginBottom + 'px';
         // Add & Remove active class on `nav-tabs` & `tab-content`.
         [...nav.children].forEach(target => {
@@ -199,22 +193,16 @@ NexT.utils = {
           bubbles: true
         }));
         // Get the height of `tab-pane` which is activated now.
-        let j;
-        for (j = 0; j < nav.children.length; j++) {
-          if (nav.children[j].classList.contains('active')) {
-            break;
-          }
-        }
         const hasScrollBar = document.body.scrollHeight > (window.innerHeight || document.documentElement.clientHeight);
-        const currHeight = parseFloat(window.getComputedStyle(tabContent.children[j]).height.replace('px', ''));
-        // Reset the height of `tab-content` and see the animation
+        const currHeight = parseFloat(window.getComputedStyle(tabContent.querySelector('.active')).height.replace('px', ''));
+        // Reset the height of `tab-content` and see the animation.
         tabContent.style.height = currHeight + paddingTop + marginBottom + 'px';
         // Change the height of `tab-content` may cause scrollbar show / disappear, which may result in the change of the `tab-pane`'s height
         setTimeout(function() {
           if ((document.body.scrollHeight > (window.innerHeight || document.documentElement.clientHeight)) !== hasScrollBar) {
             tabContent.style.transition = 'height 0.3s linear';
             // After the animation, we need reset the height of `tab-content` again.
-            const currHeightAfterScrollBarChange = parseFloat(window.getComputedStyle(tabContent.children[j]).height.replace('px', ''));
+            const currHeightAfterScrollBarChange = parseFloat(window.getComputedStyle(tabContent.querySelector('.active')).height.replace('px', ''));
             tabContent.style.height = currHeightAfterScrollBarChange + paddingTop + marginBottom + 'px';
           }
           // Remove all the inline styles, and let the height be adaptive again.

--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -175,9 +175,9 @@ NexT.utils = {
         const tabContent = nav.nextElementSibling;
         tabContent.style.overflow = 'hidden';
         tabContent.style.transition = 'height 1s';
-        const prevHeight = parseFloat(window.getComputedStyle(tabContent.querySelector('.active')).height.replace('px', ''));
-        const paddingTop = parseFloat(window.getComputedStyle(tabContent.querySelector('.active')).paddingTop.replace('px', ''));
-        const marginBottom = parseFloat(window.getComputedStyle(tabContent.querySelector('.active').firstChild).marginBottom.replace('px', ''));
+        const prevHeight = parseInt(window.getComputedStyle(tabContent.querySelector('.active')).height.replace('px', ''));
+        const paddingTop = parseInt(window.getComputedStyle(tabContent.querySelector('.active')).paddingTop.replace('px', ''));
+        const marginBottom = parseInt(window.getComputedStyle(tabContent.querySelector('.active').firstChild).marginBottom.replace('px', ''));
         tabContent.style.height = prevHeight + paddingTop + marginBottom + 'px';
         // Add & Remove active class on `nav-tabs` & `tab-content`.
         [...nav.children].forEach(target => {
@@ -194,7 +194,7 @@ NexT.utils = {
         }));
         // Get the height of `tab-pane` which is activated now.
         const hasScrollBar = document.body.scrollHeight > (window.innerHeight || document.documentElement.clientHeight);
-        const currHeight = parseFloat(window.getComputedStyle(tabContent.querySelector('.active')).height.replace('px', ''));
+        const currHeight = parseInt(window.getComputedStyle(tabContent.querySelector('.active')).height.replace('px', ''));
         // Reset the height of `tab-content` and see the animation.
         tabContent.style.height = currHeight + paddingTop + marginBottom + 'px';
         // Change the height of `tab-content` may cause scrollbar show / disappear, which may result in the change of the `tab-pane`'s height
@@ -202,7 +202,7 @@ NexT.utils = {
           if ((document.body.scrollHeight > (window.innerHeight || document.documentElement.clientHeight)) !== hasScrollBar) {
             tabContent.style.transition = 'height 0.3s linear';
             // After the animation, we need reset the height of `tab-content` again.
-            const currHeightAfterScrollBarChange = parseFloat(window.getComputedStyle(tabContent.querySelector('.active')).height.replace('px', ''));
+            const currHeightAfterScrollBarChange = parseInt(window.getComputedStyle(tabContent.querySelector('.active')).height.replace('px', ''));
             tabContent.style.height = currHeightAfterScrollBarChange + paddingTop + marginBottom + 'px';
           }
           // Remove all the inline styles, and let the height be adaptive again.

--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -171,6 +171,20 @@ NexT.utils = {
         // Prevent selected tab to select again.
         if (element.classList.contains('active')) return;
         const nav = element.parentNode;
+        // Get the height of `tab-pane` which is activated before, and set it as the height of `tab-content` with extra margin / paddings.
+        for (var i = 0; i < nav.children.length; i++) {
+          if (nav.children[i].classList.contains('active')) {
+            break;
+          }
+        }
+        const tabContent = nav.nextElementSibling;
+        tabContent.style.overflow = 'hidden';
+        tabContent.style.transition = 'height 1s'
+        const prevHeight = parseFloat(window.getComputedStyle(tabContent.children[i]).height.replace('px', ''));
+        const paddingTop = parseFloat(window.getComputedStyle(tabContent.children[i]).paddingTop.replace('px', ''));
+        const marginBottom = parseFloat(window.getComputedStyle(tabContent.children[i].firstChild).marginBottom.replace('px', ''));
+        tabContent.style.height = prevHeight + paddingTop + marginBottom + 'px';
+        
         // Add & Remove active class on `nav-tabs` & `tab-content`.
         [...nav.children].forEach(target => {
           target.classList.toggle('active', target === element);
@@ -184,6 +198,30 @@ NexT.utils = {
         tActive.dispatchEvent(new Event('tabs:click', {
           bubbles: true
         }));
+        // Get the height of `tab-pane` which is activated now.
+        for (var j = 0; j < nav.children.length; j++) {
+          if (nav.children[j].classList.contains('active')) {
+            break;
+          }
+        }
+        const hasScrollBar = document.body.scrollHeight > (window.innerHeight || document.documentElement.clientHeight);
+        const currHeight = parseFloat(window.getComputedStyle(tabContent.children[j]).height.replace('px', ''));
+        // Reset the height of `tab-content` and see the animation 
+        tabContent.style.height = currHeight + paddingTop + marginBottom + 'px';
+        // Change the height of `tab-content` may cause scrollbar show / disappear, which may result in the change of the `tab-pane`'s height 
+        setTimeout(function () {
+          if (document.body.scrollHeight > (window.innerHeight || document.documentElement.clientHeight) !== hasScrollBar){
+            tabContent.style.transition = 'height 0.3s linear';
+            // After the animation, we need reset the height of `tab-content` again.
+            const currHeightAfterScrollBarChange = parseFloat(window.getComputedStyle(tabContent.children[j]).height.replace('px', ''));
+            tabContent.style.height = currHeightAfterScrollBarChange + paddingTop + marginBottom + 'px';
+          }
+          // Remove all the inline styles, and let the height be adaptive again.
+          setTimeout(function () {
+            tabContent.style.transition = '';
+            tabContent.style.height = '';
+          }, 250)
+        }, 1000);
         if (!CONFIG.stickytabs) return;
         const offset = nav.parentNode.getBoundingClientRect().top + window.scrollY + 10;
         window.anime({


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->
As mentioned in https://github.com/next-theme/hexo-theme-next/issues/592, there is no transtion animation for `tab-content` now.

## What is the new behavior?
<!-- Description about this pull, in several words -->
Add transition animation for the hight of `tab-content` when tab switches.
- Link to demo site with this changes:
- Screenshots with this changes:

### How to use?

In NexT `_config.yml`:
```

```
