### PR TITLE
Improve accessibility

### DIFF
--- a/layout/_partials/header/brand.njk
+++ b/layout/_partials/header/brand.njk
@@ -28,7 +28,7 @@
   </div>
 
   <div class="site-nav-right">
-    <div class="toggle popup-trigger">
+    <div class="toggle popup-trigger" aria-label="{{ __('menu.search') }}" role="button">
       {%- if theme.algolia_search.enable or theme.local_search.enable %}
         <i class="fa fa-search fa-fw fa-lg"></i>
       {%- endif %}

--- a/layout/_partials/pagination.njk
+++ b/layout/_partials/pagination.njk
@@ -1,12 +1,5 @@
 {%- if page.prev or page.next %}
   <nav class="pagination">
-    {{
-      paginator({
-        prev_text: '<i class="fa fa-angle-left" aria-label="' + __('accessibility.prev_page') + '"></i>',
-        next_text: '<i class="fa fa-angle-right" aria-label="' + __('accessibility.next_page') + '"></i>',
-        mid_size : 1,
-        escape   : false
-      })
-    }}
+    {{ next_paginator() }}
   </nav>
 {%- endif %}

--- a/scripts/helpers/next-paginator.js
+++ b/scripts/helpers/next-paginator.js
@@ -1,0 +1,18 @@
+/* global hexo */
+
+'use strict';
+
+hexo.extend.helper.register('next_paginator', function() {
+  const prev = this.__('accessibility.prev_page');
+  const next = this.__('accessibility.next_page');
+  let paginator = this.paginator({
+    prev_text: '<i class="fa fa-angle-left"></i>',
+    next_text: '<i class="fa fa-angle-right"></i>',
+    mid_size : 1,
+    escape   : false
+  });
+  paginator = paginator
+    .replace('rel="prev"', `rel="prev" title="${prev}" aria-label="${prev}"`)
+    .replace('rel="next"', `rel="next" title="${next}" aria-label="${next}"`);
+  return paginator;
+});


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue resolved:

https://pagespeed.web.dev/report?url=https%3A%2F%2Ftheme-next.js.org%2F&form_factor=desktop

<img width="893" alt="截屏2022-11-18 13 50 42" src="https://user-images.githubusercontent.com/16272760/202630380-20e7c00b-3553-4a93-8350-add404e9a541.png">

See also https://github.com/theme-next/hexo-theme-next/pull/130

## What is the new behavior?
<!-- Description about this pull, in several words -->

- Link to demo site with this changes:
- Screenshots with this changes:

### How to use?

In NexT `_config.yml`:
```yml

```
