### PR TITLE
Add rel="me" to social links

### DIFF
--- a/layout/_partials/sidebar/site-overview.njk
+++ b/layout/_partials/sidebar/site-overview.njk
@@ -67,7 +67,7 @@
         {%- set sidebarURL = link.split('||')[0] | trim %}
         {%- set sidebarIcon = '<i class="' + link.split('||')[1] | trim + ' fa-fw"></i>' if theme.social_icons.enable and link.split('||')[1] else '' %}
         {%- set sidebarText = '' if (theme.social_icons.enable and theme.social_icons.icons_only) else name %}
-        {{ next_url(sidebarURL, sidebarIcon + sidebarText, {title: name + ' → ' + sidebarURL}) }}
+        {{ next_url(sidebarURL, sidebarIcon + sidebarText, {title: name + ' → ' + sidebarURL, rel: 'noopener me'}) }}
       </span>
     {%- endfor %}
   </div>

--- a/scripts/helpers/next-url.js
+++ b/scripts/helpers/next-url.js
@@ -42,7 +42,7 @@ module.exports = function(path, text, options = {}) {
 
     if (!theme.exturl) {
       // Only for simple link need to rewrite/add attributes.
-      attrs.rel = 'noopener';
+      attrs.rel = attrs.rel || 'noopener';
       attrs.target = '_blank';
     } else {
       // Remove rel attributes for `exturl` in main menu.


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. NexT includes 4 schemes: Muse and Mist have similar structure, but Pisces and Gemini are very different from them. It is possible that one scheme works fine after the changes, but another scheme is broken. Please make the tests in different schemes to make sure the changes are compatible with all schemes.

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] The changes have been tested (for bug fixes / features).
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [ ] Feature.
- [x] Improvement.
- [ ] Code style update (formatting, linting).
- [ ] Refactoring (no functional changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
Issue resolved: #604 

## What is the new behavior?
Social links have `rel="noopener me"` attribute and can be verified by Mastodon or other social services.

- Link to demo site with this changes: https://mudkip.me

### How to use?

In NexT `_config.next.yml`:
```yml
social:
  Mastodon: https://indieweb.social/@mudkip || fab fa-mastodon
```
