### PR TITLE
Remove hidden .site-nav from accessibility tree

### DIFF
--- a/source/css/_mixins.styl
+++ b/source/css/_mixins.styl
@@ -226,7 +226,9 @@ site-nav-hide-by-default() {
   --scroll-height: 0;
   height: 0;
   overflow: hidden;
-  transition: height $transition-ease;
+  transition: $transition-ease;
+  transition-property: height, visibility;
+  visibility: hidden;
 
   body:not(.site-nav-on) & .animated {
     animation: none;
@@ -234,6 +236,7 @@ site-nav-hide-by-default() {
 
   body.site-nav-on & {
     height: var(--scroll-height);
+    visibility: unset;
   }
 }
 


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. NexT includes 4 schemes: Muse and Mist have similar structure, but Pisces and Gemini are very different from them. It is possible that one scheme works fine after the changes, but another scheme is broken. Please make the tests in different schemes to make sure the changes are compatible with all schemes.

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] The changes have been tested (for bug fixes / features).
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Improvement.
- [ ] Code style update (formatting, linting).
- [ ] Refactoring (no functional changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->
The hidden `.site-nav` is still accessible, which means
* it will still receive focus through sequential keyboard navigation using the `Tab` key,
* it will still be announced by screen reading technology.

Issue resolved:

## What is the new behavior?
<!-- Description about this pull, in several words -->
The hidden `.site-nav` is removed from the accessibility tree via `visibility: hidden`.

- Link to demo site with this changes:
- Screenshots with this changes:

### How to use?

In NexT `_config.yml`:
```yml

```
