### PR TITLE
Support reprint

### DIFF
--- a/languages/en.yml
+++ b/languages/en.yml
@@ -41,7 +41,7 @@ post:
     post_link: This article originally appeared on
     license_title: Copyright Notice
     license_content: "All articles in this blog are licensed under %s unless stating additionally."
-
+    license_content_reprint: "This article is a reprinted article and has been reprinted with permission. Please indicate the source!"
 footer:
   powered: "Powered by %s"
   total_views: Total Views

--- a/languages/zh-CN.yml
+++ b/languages/zh-CN.yml
@@ -38,6 +38,7 @@ post:
     post_link: 原文链接
     license_title: 版权声明
     license_content: "本博客所有文章除特别声明外，均采用 %s 许可协议。转载请注明出处！"
+    license_content_reprint: "本文章为转载文章，已获转载许可。转载请注明出处！"
 footer:
   powered: "由 %s 强力驱动"
   total_views: 总访问量

--- a/layout/_partials/post/post-copyright.njk
+++ b/layout/_partials/post/post-copyright.njk
@@ -22,8 +22,13 @@
     {%- endif %}
   </li>
   <li class="post-copyright-license">
-    <strong>{{ __('post.copyright.license_title') + __('symbol.colon') }} </strong>
-    {{- __('post.copyright.license_content', next_url(ccURL, ccIcon + ccText)) }}
+    {%- if page.copyright_reprint %}
+      <strong>{{ __('post.copyright.license_title') + __('symbol.colon') }} </strong>
+      {{- __('post.copyright.license_content_reprint', next_url(ccURL, ccIcon + ccText)) }}
+    {%- else %}
+      <strong>{{ __('post.copyright.license_title') + __('symbol.colon') }} </strong>
+      {{- __('post.copyright.license_content', next_url(ccURL, ccIcon + ccText)) }}
+    {%- endif %}
   </li>
 </ul>
 </div>


### PR DESCRIPTION


## PR Checklist

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] The changes have been tested (for bug fixes / features).
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Improvement.
- [ ] Code style update (formatting, linting).
- [ ] Refactoring (no functional changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
This will allow us to set proper copyright notices for reposted articles when the article is reposted! Let's respect article copyright in a better way! And make sure we don't constitute infringement!

This will allow the copyright statement of the article to evolve from a fixed statement on the page to an article-level copyright statement! Appropriate declarations will be set for each article!

Issue resolved:

## What is the new behavior?

When the article has the following matterfont, enable the copyright statement of the reprinted article!

```
---
copyright_reprint: true
---
```

### How to use?


When the article has the following matterfont, enable the copyright statement of the reprinted article!

```
---
copyright_reprint: true
---
```
