### PR TITLE
add `font.url` to import self-host fonts.

### DIFF
--- a/scripts/helpers/font.js
+++ b/scripts/helpers/font.js
@@ -20,6 +20,9 @@ module.exports = function() {
   fontFamilies = fontFamilies.map(name => name.trim().replace(/\s/g, '+') + fontStyles);
   fontFamilies = [...new Set(fontFamilies)].join('%7C');
 
+  const fontURL= config.url || `"${fontHost}/css?family=${fontFamilies}&display=swap&subset=latin,latin-ext"`
+  // console.info("fontURL:"+fontURL)
+
   // Merge extra parameters to the final processed font string
-  return fontFamilies ? `<link rel="stylesheet" href="${fontHost}/css?family=${fontFamilies}&display=swap&subset=latin,latin-ext">` : '';
+  return fontFamilies ? `<link rel="stylesheet" href="${fontURL}">` : '';
 };


### PR DESCRIPTION
self-host can be github pages.

<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. NexT includes 4 schemes: Muse and Mist have similar structure, but Pisces and Gemini are very different from them. It is possible that one scheme works fine after the changes, but another scheme is broken. Please make the tests in different schemes to make sure the changes are compatible with all schemes.

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] The changes have been tested (for bug fixes / features).
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [ ] Feature.
- [x] Improvement.
- [ ] Code style update (formatting, linting).
- [ ] Refactoring (no functional changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue resolved:

add `font.url` to import self-host fonts.
self-host can be github pages.


## What is the new behavior?
use self-host fonts files host on github page.


### How to use?

In NexT `_config.yml`:
```yml
font:
  enable: true
  url: https://xxx.github.io/gfont/fonts/NotoSerifSC/fonts_font_im_local.css
```
