### PR TITLE
Feat: Add new inject point - postBodyStart

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,7 @@ custom_file_path:
   #header: source/_data/header.njk
   #sidebar: source/_data/sidebar.njk
   #postMeta: source/_data/post-meta.njk
+  #postBodyStart: source/_data/post-body-start.njk
   #postBodyEnd: source/_data/post-body-end.njk
   #footer: source/_data/footer.njk
   #bodyEnd: source/_data/body-end.njk

--- a/layout/_macro/post.njk
+++ b/layout/_macro/post.njk
@@ -90,7 +90,8 @@
           {{ post.content }}
         {%- endif %}
       {% else %}
-        {{ post.content }}
+        {{- next_inject('postBodyStart') }}
+        {{- post.content }}
       {%- endif %}
     </div>
 

--- a/scripts/events/lib/utils.js
+++ b/scripts/events/lib/utils.js
@@ -63,6 +63,7 @@ const points = {
     'header',
     'sidebar',
     'postMeta',
+    'postBodyStart',
     'postBodyEnd',
     'footer',
     'bodyEnd',


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. NexT includes 4 schemes: Muse and Mist have similar structure, but Pisces and Gemini are very different from them. It is possible that one scheme works fine after the changes, but another scheme is broken. Please make the tests in different schemes to make sure the changes are compatible with all schemes.

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] The changes have been tested (for bug fixes / features).
- [ ] **I will submit a PR for docs later** [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Improvement.
- [ ] Code style update (formatting, linting).
- [ ] Refactoring (no functional changes).
- [ ] Documentation.
- [x] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the new behavior?

Add a new hook that can prepend data before the post content.

https://blog.singee.me/2023/04/21/439c2231088e47d6a36502ca5427dbf1/

The text `本文首发于 xlog，可跳转获得更佳阅读体验` is added with use of this inject.

### How to use?

In NexT `_config.yml`:
```yml
custom_file_path:
  postBodyStart: source/_data/post-body-start.njk
```
