### PR TITLE
Update Google Analytics only_pageview mode to GA4

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -762,6 +762,8 @@ google_analytics:
   # By default, NexT will load an external gtag.js script on your site.
   # If you only need the pageview feature, set the following option to true to get a better performance.
   only_pageview: false
+  # only needed if you are using `only_pageview` mode, https://developers.google.com/analytics/devguides/collection/protocol/ga4
+  measure_protocol_api_secret:
 
 # Baidu Analytics
 # See: https://tongji.baidu.com

--- a/source/js/third-party/analytics/google-analytics.js
+++ b/source/js/third-party/analytics/google-analytics.js
@@ -22,13 +22,31 @@ if (!CONFIG.google_analytics.only_pageview) {
     if (CONFIG.hostname !== location.hostname) return;
     const uid = localStorage.getItem('uid') || (Math.random() + '.' + Math.random());
     localStorage.setItem('uid', uid);
-    navigator.sendBeacon('https://www.google-analytics.com/collect', new URLSearchParams({
-      v  : 1,
-      tid: CONFIG.google_analytics.tracking_id,
-      cid: uid,
-      t  : 'pageview',
-      dp : encodeURIComponent(location.pathname)
-    }));
+    fetch(
+      'https://www.google-analytics.com/mp/collect?' + new URLSearchParams({
+        api_secret    : CONFIG.google_analytics.measure_protocol_api_secret,
+        measurement_id: CONFIG.google_analytics.tracking_id
+      }),
+      {
+        method : 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          client_id: uid,
+          events   : [
+            {
+              name  : 'page_view',
+              params: {
+                page_location: location.href,
+                page_title   : document.title
+              }
+            }
+          ]
+        }),
+        mode: 'no-cors'
+      }
+    );
   };
   document.addEventListener('pjax:complete', sendPageView);
   sendPageView();


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. NexT includes 4 schemes: Muse and Mist have similar structure, but Pisces and Gemini are very different from them. It is possible that one scheme works fine after the changes, but another scheme is broken. Please make the tests in different schemes to make sure the changes are compatible with all schemes.

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] The changes have been tested (for bug fixes / features).
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [ ] Feature.
- [ ] Improvement.
- [ ] Code style update (formatting, linting).
- [ ] Refactoring (no functional changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [x] Other... Please describe: Replace the usage of the to be depreacted Universal Analytics measurement protocol api with the new api. ([source](https://support.google.com/analytics/answer/11583528?hl=en))

## What is the current behavior?

The custom pageview sending code (will be used when `only_pageview` is enabled) is using the old measurement protocol api.

## What is the new behavior?

Use the new GA4 measurement protocol api instead: https://developers.google.com/analytics/devguides/collection/protocol/ga4

- Link to demo site with this changes:
- Screenshots with this changes:

### How to use?

Create a new Google Analytics 4 resource, and get `api_secret` according to the instruction described [here](https://developers.google.com/analytics/devguides/collection/protocol/ga4/sending-events?client_type=gtag).

In NexT `_config.yml`:
```yml
google_analytics:
  tracking_id: G-XXXXXXXXXX  # Measurement ID
  only_pageview: true
  measure_protocol_api_secret: # api secret
```
