### PR TITLE
Add wavedrom support.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -532,6 +532,9 @@ mermaid:
     light: default
     dark: dark
 
+# Wavedrom tag
+wavedrom:
+  enable: false
 
 # ---------------------------------------------------------------
 # Third Party Plugins & Services Settings

--- a/_config.yml
+++ b/_config.yml
@@ -532,7 +532,7 @@ mermaid:
     light: default
     dark: dark
 
-# Wavedrom tag
+# WaveDrom tag
 wavedrom:
   enable: false
 

--- a/_vendors.yml
+++ b/_vendors.yml
@@ -173,12 +173,12 @@ creative_commons:
   dir: assets/license_badges
   alias: creativecommons-vocabulary
 wavedrom:
-  name: 'wavedrom'
+  name: wavedrom
   version: 3.2.0
   file: wavedrom.min.js
   integrity: sha512-/ZL0uQxVV1wYyWlpO4klZ1a39eaBz4zESSamuBMaMsZ6le3YejJ07hmLlHoCTXrKz5eYtEuO5K1BcTo+lQpQJA==
 wavedrom_skin:
-  name: 'wavedrom'
+  name: wavedrom
   version: 3.2.0
-  file: skins/default.min.js
-  integrity: sha512-SDH/iWIRSg0ujndO7Np7wyJF/zs8JHp4tHKU4VJuraJ3ASd2sVorT/3uA2xnHthywvei4/fJYz8Lsbr1SChYBQ==
+  file: skins/default.js
+  integrity: sha512-GV5gOBpCHd3M5Af9Ooz+I9dQdwcDKPR2F8ulzCpoF4W6uwmtLTh/pT8Q1XupPmQJO+Kt88/DrIiK7PzR1YLvwQ==

--- a/_vendors.yml
+++ b/_vendors.yml
@@ -172,3 +172,13 @@ creative_commons:
   version: 2020.11.3
   dir: assets/license_badges
   alias: creativecommons-vocabulary
+wavedrom:
+  name: 'wavedrom'
+  version: 3.2.0
+  file: wavedrom.min.js
+  integrity: sha512-/ZL0uQxVV1wYyWlpO4klZ1a39eaBz4zESSamuBMaMsZ6le3YejJ07hmLlHoCTXrKz5eYtEuO5K1BcTo+lQpQJA==
+wavedrom_skin:
+  name: 'wavedrom'
+  version: 3.2.0
+  file: skins/default.min.js
+  integrity: sha512-SDH/iWIRSg0ujndO7Np7wyJF/zs8JHp4tHKU4VJuraJ3ASd2sVorT/3uA2xnHthywvei4/fJYz8Lsbr1SChYBQ==

--- a/layout/_third-party/index.njk
+++ b/layout/_third-party/index.njk
@@ -14,6 +14,7 @@
 
 {%- include 'tags/pdf.njk' -%}
 {%- include 'tags/mermaid.njk' -%}
+{%- include 'tags/wavedrom.njk' -%}
 
 {%- include 'fancybox.njk' -%}
 {%- include 'pace.njk' -%}

--- a/layout/_third-party/tags/wavedrom.njk
+++ b/layout/_third-party/tags/wavedrom.njk
@@ -1,0 +1,9 @@
+{%- if theme.wavedrom.enable %}
+  {{ next_data('wavedrom', theme.wavedrom, {
+    js: theme.vendors.wavedrom
+  }) }}
+  {{ next_data('wavedrom_skin', theme.wavedrom, {
+    js: theme.vendors.wavedrom_skin
+  }) }}
+  {{ next_js('third-party/tags/wavedrom.js') }}
+{%- endif %}

--- a/scripts/filters/minify.js
+++ b/scripts/filters/minify.js
@@ -137,6 +137,10 @@ hexo.extend.filter.register('after_generate', () => {
     hexo.route.remove('js/third-party/tags/pdf.js');
   }
 
+  if (!theme.wavedrom.enable) {
+    hexo.route.remove('js/third-party/tags/wavedrom.js');
+  }
+
   // Others
   if (!theme.fancybox) {
     hexo.route.remove('js/third-party/fancybox.js');

--- a/scripts/tags/index.js
+++ b/scripts/tags/index.js
@@ -35,6 +35,10 @@ const mermaid = require('./mermaid');
 
 hexo.extend.tag.register('mermaid', mermaid, true);
 
+const wavedrom = require('./wavedrom');
+
+hexo.extend.tag.register('wavedrom', wavedrom, true);
+
 const postNote = require('./note')(hexo);
 
 hexo.extend.tag.register('note', postNote, true);

--- a/scripts/tags/wavedrom.js
+++ b/scripts/tags/wavedrom.js
@@ -8,6 +8,6 @@ const { escapeHTML } = require('hexo-util');
 
 module.exports = function(args, content) {
   return `<script type="WaveDrom">
-${escapeHTML(content)}
+${content}
 </script>`;
 };

--- a/scripts/tags/wavedrom.js
+++ b/scripts/tags/wavedrom.js
@@ -5,7 +5,7 @@
 'use strict';
 
 module.exports = function(args, content) {
-  return `<script type="WaveDrom">
+  return `<div class="wavedrom"><script type="WaveDrom">
 ${content}
-</script>`;
+</script></div>`;
 };

--- a/scripts/tags/wavedrom.js
+++ b/scripts/tags/wavedrom.js
@@ -4,8 +4,6 @@
 
 'use strict';
 
-const { escapeHTML } = require('hexo-util');
-
 module.exports = function(args, content) {
   return `<script type="WaveDrom">
 ${content}

--- a/scripts/tags/wavedrom.js
+++ b/scripts/tags/wavedrom.js
@@ -1,0 +1,13 @@
+/**
+ * wavedrom.js | https://theme-next.js.org/docs/tag-plugins/wavedrom
+ */
+
+'use strict';
+
+const { escapeHTML } = require('hexo-util');
+
+module.exports = function(args, content) {
+  return `<script type="WaveDrom">
+${escapeHTML(content)}
+</script>`;
+};

--- a/source/css/_common/scaffolding/tags/index.styl
+++ b/source/css/_common/scaffolding/tags/index.styl
@@ -3,6 +3,7 @@
 @import 'label';
 @import 'link-grid';
 @import 'mermaid';
+@import 'wavedrom';
 @import 'note';
 @import 'pdf';
 @import 'tabs';

--- a/source/css/_common/scaffolding/tags/wavedrom.styl
+++ b/source/css/_common/scaffolding/tags/wavedrom.styl
@@ -1,0 +1,6 @@
+if (hexo-config('wavedrom.enable')) {
+  .wavedrom {
+    margin-bottom: 20px;
+    text-align: center;
+  }
+}

--- a/source/js/third-party/tags/wavedrom.js
+++ b/source/js/third-party/tags/wavedrom.js
@@ -1,0 +1,11 @@
+/* global NexT, CONFIG, wavedrom */
+
+document.addEventListener('page:loaded', () => {
+    NexT.utils.getScript(CONFIG.wavedrom.js, {
+      condition: window.wavedrom
+    }).then(() => {
+        NexT.utils.getScript(CONFIG.wavedrom_skin.js).then(() => {
+            WaveDrom.ProcessAll()
+        });
+    });
+});

--- a/source/js/third-party/tags/wavedrom.js
+++ b/source/js/third-party/tags/wavedrom.js
@@ -1,11 +1,11 @@
-/* global NexT, CONFIG, wavedrom */
+/* global NexT, CONFIG, WaveDrom */
 
 document.addEventListener('page:loaded', () => {
-    NexT.utils.getScript(CONFIG.wavedrom.js, {
-      condition: window.wavedrom
-    }).then(() => {
-        NexT.utils.getScript(CONFIG.wavedrom_skin.js).then(() => {
-            WaveDrom.ProcessAll()
-        });
+  NexT.utils.getScript(CONFIG.wavedrom.js, {
+    condition: window.WaveDrom
+  }).then(() => {
+    NexT.utils.getScript(CONFIG.wavedrom_skin.js).then(() => {
+      WaveDrom.ProcessAll();
     });
+  });
 });

--- a/source/js/third-party/tags/wavedrom.js
+++ b/source/js/third-party/tags/wavedrom.js
@@ -4,7 +4,9 @@ document.addEventListener('page:loaded', () => {
   NexT.utils.getScript(CONFIG.wavedrom.js, {
     condition: window.WaveDrom
   }).then(() => {
-    NexT.utils.getScript(CONFIG.wavedrom_skin.js).then(() => {
+    NexT.utils.getScript(CONFIG.wavedrom_skin.js, {
+      condition: window.WaveSkin
+    }).then(() => {
       WaveDrom.ProcessAll();
     });
   });


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. NexT includes 4 schemes: Muse and Mist have similar structure, but Pisces and Gemini are very different from them. It is possible that one scheme works fine after the changes, but another scheme is broken. Please make the tests in different schemes to make sure the changes are compatible with all schemes.

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] The changes have been tested (for bug fixes / features).
- [x] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
  - PR is here: <https://github.com/next-theme/theme-next-docs/pull/101>.
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Improvement.
- [ ] Code style update (formatting, linting).
- [ ] Refactoring (no functional changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?

Currently next theme doesn't have wavedrom tag support, and we will have to use markdown image tag to send to wavedrom rendering server to generate the graph. However, this approach can be slow. And if the code is long, the request will fail. Hence, it is better to add wavedrom code block rendering support within the theme.

Issue resolved: Rendering wavedrom code block.

## What is the new behavior?

After the change, we can directly add wavedrom code and render it as graph.

- Link to demo site with this changes: <https://r12f.com/posts/use-wavedrom-in-hexo/>
- Screenshots with this changes: ![image](https://github.com/next-theme/hexo-theme-next/assets/1533278/2dbcf971-da45-4e3c-bfc8-462b3eb7b9ac)

### How to use?

In NexT `_config.yml`:

```yml
# Wavedrom tag
wavedrom:
  enable: true
```

Then write code like below:

```
{% wavedrom %}
{ signal : [
  { name: "clk",  wave: "p......" },
  { name: "bus",  wave: "x.34.5x",   data: "head body tail" },
  { name: "wire", wave: "0.1..0." },
]}
{% endwavedrom %}
```