### PR TITLE
Upgrade to fancybox 5

### DIFF
--- a/_vendors.yml
+++ b/_vendors.yml
@@ -58,11 +58,13 @@ fancybox_js:
   version: 5.0.20
   file: dist/fancybox/fancybox.umd.js
   alias: fancyapps-ui
+  integrity: sha256-q8XkJ6dj5VwSvzI8+nATCHHQG+Xv/dAZBCgqmu93zOY=
 fancybox_css:
   name: '@fancyapps/ui'
   version: 5.0.20
   file: dist/fancybox/fancybox.css
   alias: fancyapps-ui
+  integrity: sha256-RvRHGSuWAxZpXKV9lLDt2e+rZ+btzn48Wp4ueS3NZKs=
 mediumzoom:
   name: medium-zoom
   version: 1.0.8

--- a/_vendors.yml
+++ b/_vendors.yml
@@ -53,23 +53,16 @@ pjax:
   file: pjax.min.js
   alias: next-theme-pjax
   integrity: sha256-vxLn1tSKWD4dqbMRyv940UYw4sXgMtYcK6reefzZrao=
-jquery:
-  name: jquery
-  version: 3.7.0
-  file: dist/jquery.min.js
-  integrity: sha256-2Pmvv0kuTBOenSvLm6bvfBSSHrUJ+3A7x6P5Ebd07/g=
 fancybox_js:
-  name: '@fancyapps/fancybox'
-  version: 3.5.7
-  file: dist/jquery.fancybox.min.js
-  alias: fancybox
-  integrity: sha256-yt2kYMy0w8AbtF89WXb2P1rfjcP/HTHLT7097U8Y5b8=
+  name: '@fancyapps/ui'
+  version: 5.0.20
+  file: dist/fancybox/fancybox.umd.js
+  alias: fancyapps-ui
 fancybox_css:
-  name: '@fancyapps/fancybox'
-  version: 3.5.7
-  file: dist/jquery.fancybox.min.css
-  alias: fancybox
-  integrity: sha256-Vzbj7sDDS/woiFS3uNKo8eIuni59rjyNGtXfstRzStA=
+  name: '@fancyapps/ui'
+  version: 5.0.20
+  file: dist/fancybox/fancybox.css
+  alias: fancyapps-ui
 mediumzoom:
   name: medium-zoom
   version: 1.0.8

--- a/scripts/helpers/next-vendors.js
+++ b/scripts/helpers/next-vendors.js
@@ -15,7 +15,7 @@ hexo.extend.helper.register('js_vendors', function() {
     vendors.push('pjax');
   }
   if (theme.fancybox) {
-    vendors.push('jquery', 'fancybox_js');
+    vendors.push('fancybox_js');
   }
   if (theme.mediumzoom) {
     vendors.push('mediumzoom');

--- a/source/css/_common/components/post/post-body.styl
+++ b/source/css/_common/components/post/post-body.styl
@@ -45,8 +45,8 @@
     margin-left: 4px;
   }
 
-  // For fancybox and pandoc
-  .image-caption, img + figcaption, .fancybox + figcaption {
+  // https://github.com/hexojs/hexo-renderer-marked/pull/264
+  img + figcaption, .fancybox + figcaption {
     color: $grey-dark;
     font-size: $font-size-small;
     font-weight: bold;

--- a/source/css/_common/outline/mobile.styl
+++ b/source/css/_common/outline/mobile.styl
@@ -53,7 +53,7 @@ if (hexo-config('mobile_layout_economy')) {
       }
 
       // Fix issue #641
-      .image-caption, img + figcaption, .fancybox + figcaption {
+      img + figcaption, .fancybox + figcaption {
         margin: -5px auto 15px !important;
       }
 

--- a/source/js/third-party/fancybox.js
+++ b/source/js/third-party/fancybox.js
@@ -13,7 +13,6 @@ document.addEventListener('page:loaded', () => {
     imageWrapLink.setAttribute('itemscope', '');
     imageWrapLink.setAttribute('itemtype', 'http://schema.org/ImageObject');
     imageWrapLink.setAttribute('itemprop', 'url');
-    image.wrap(imageWrapLink);
 
     let dataFancybox = 'default';
     if (image.closest('.post-gallery') !== null) {
@@ -25,17 +24,11 @@ document.addEventListener('page:loaded', () => {
 
     const imageTitle = image.title || image.alt;
     if (imageTitle) {
-      // Do not append image-caption if pandoc has already created a figcaption
-      if (!imageWrapLink.nextElementSibling || imageWrapLink.nextElementSibling.tagName.toLowerCase() !== 'figcaption') {
-        const imageCaption = document.createElement('p');
-        imageCaption.classList.add('image-caption');
-        imageCaption.textContent = imageTitle;
-        imageWrapLink.appendChild(imageCaption);
-      }
-      // Make sure img title tag will show correctly in fancybox
       imageWrapLink.title = imageTitle;
+      // Make sure img captions will show correctly in fancybox
       imageWrapLink.dataset.caption = imageTitle;
     }
+    image.wrap(imageWrapLink);
   });
 
   Fancybox.bind('[data-fancybox]');

--- a/source/js/third-party/fancybox.js
+++ b/source/js/third-party/fancybox.js
@@ -5,30 +5,38 @@ document.addEventListener('page:loaded', () => {
   /**
    * Wrap images with fancybox.
    */
-  document.querySelectorAll('.post-body :not(a) > img, .post-body > img').forEach(element => {
-    const $image = $(element);
-    const imageLink = $image.attr('data-src') || $image.attr('src');
-    const $imageWrapLink = $image.wrap(`<a class="fancybox fancybox.image" href="${imageLink}" itemscope itemtype="http://schema.org/ImageObject" itemprop="url"></a>`).parent('a');
-    if ($image.is('.post-gallery img')) {
-      $imageWrapLink.attr('data-fancybox', 'gallery').attr('rel', 'gallery');
-    } else if ($image.is('.group-picture img')) {
-      $imageWrapLink.attr('data-fancybox', 'group').attr('rel', 'group');
+  document.querySelectorAll('.post-body :not(a) > img, .post-body > img').forEach(image => {
+    const imageLink = image.getAttribute('data-src') || image.getAttribute('src');
+    const imageWrapLink = document.createElement('a');
+    imageWrapLink.classList.add('fancybox');
+    imageWrapLink.href = imageLink;
+    imageWrapLink.setAttribute('itemscope', '');
+    imageWrapLink.setAttribute('itemtype', 'http://schema.org/ImageObject');
+    imageWrapLink.setAttribute('itemprop', 'url');
+    image.wrap(imageWrapLink);
+
+    if (image.closest('.post-gallery') !== null) {
+      imageWrapLink.setAttribute('data-fancybox', 'gallery');
+    } else if (image.closest('.group-picture') !== null) {
+      imageWrapLink.setAttribute('data-fancybox', 'group');
     } else {
-      $imageWrapLink.attr('data-fancybox', 'default').attr('rel', 'default');
+      imageWrapLink.setAttribute('data-fancybox', 'default');
     }
 
-    const imageTitle = $image.attr('title') || $image.attr('alt');
+    const imageTitle = image.getAttribute('title') || image.getAttribute('alt');
     if (imageTitle) {
       // Do not append image-caption if pandoc has already created a figcaption
-      if (!$imageWrapLink.next('figcaption').length) {
-        $imageWrapLink.append(`<p class="image-caption">${imageTitle}</p>`);
+      if (!imageWrapLink.nextElementSibling || imageWrapLink.nextElementSibling.tagName.toLowerCase() !== 'figcaption') {
+        const imageCaption = document.createElement('p');
+        imageCaption.classList.add('image-caption');
+        imageCaption.textContent = imageTitle;
+        imageWrapLink.appendChild(imageCaption);
       }
       // Make sure img title tag will show correctly in fancybox
-      $imageWrapLink.attr('title', imageTitle).attr('data-caption', imageTitle);
+      imageWrapLink.title = imageTitle;
+      imageWrapLink.dataset.caption = imageTitle;
     }
   });
 
-  Fancybox.bind('[data-fancybox]', {
-    // Your custom options
-  });
+  Fancybox.bind('[data-fancybox]');
 });

--- a/source/js/third-party/fancybox.js
+++ b/source/js/third-party/fancybox.js
@@ -6,7 +6,7 @@ document.addEventListener('page:loaded', () => {
    * Wrap images with fancybox.
    */
   document.querySelectorAll('.post-body :not(a) > img, .post-body > img').forEach(image => {
-    const imageLink = image.getAttribute('data-src') || image.getAttribute('src');
+    const imageLink = image.dataset.src || image.src;
     const imageWrapLink = document.createElement('a');
     imageWrapLink.classList.add('fancybox');
     imageWrapLink.href = imageLink;
@@ -15,15 +15,15 @@ document.addEventListener('page:loaded', () => {
     imageWrapLink.setAttribute('itemprop', 'url');
     image.wrap(imageWrapLink);
 
+    let dataFancybox = 'default';
     if (image.closest('.post-gallery') !== null) {
-      imageWrapLink.setAttribute('data-fancybox', 'gallery');
+      dataFancybox = 'gallery';
     } else if (image.closest('.group-picture') !== null) {
-      imageWrapLink.setAttribute('data-fancybox', 'group');
-    } else {
-      imageWrapLink.setAttribute('data-fancybox', 'default');
+      dataFancybox = 'group';
     }
+    imageWrapLink.dataset.fancybox = dataFancybox;
 
-    const imageTitle = image.getAttribute('title') || image.getAttribute('alt');
+    const imageTitle = image.title || image.alt;
     if (imageTitle) {
       // Do not append image-caption if pandoc has already created a figcaption
       if (!imageWrapLink.nextElementSibling || imageWrapLink.nextElementSibling.tagName.toLowerCase() !== 'figcaption') {

--- a/source/js/third-party/fancybox.js
+++ b/source/js/third-party/fancybox.js
@@ -1,3 +1,5 @@
+/* global Fancybox */
+
 document.addEventListener('page:loaded', () => {
 
   /**
@@ -26,13 +28,7 @@ document.addEventListener('page:loaded', () => {
     }
   });
 
-  $.fancybox.defaults.hash = false;
-  $('.fancybox').fancybox({
-    loop   : true,
-    helpers: {
-      overlay: {
-        locked: false
-      }
-    }
+  Fancybox.bind('[data-fancybox]', {
+    // Your custom options
   });
 });


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. NexT includes 4 schemes: Muse and Mist have similar structure, but Pisces and Gemini are very different from them. It is possible that one scheme works fine after the changes, but another scheme is broken. Please make the tests in different schemes to make sure the changes are compatible with all schemes.

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] The changes have been tested (for bug fixes / features).
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Improvement.
- [ ] Code style update (formatting, linting).
- [ ] Refactoring (no functional changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue resolved: https://github.com/theme-next/hexo-theme-next/issues/1525

## What is the new behavior?
<!-- Description about this pull, in several words -->

- Link to demo site with this changes:
- Screenshots with this changes:

### How to use?

In NexT `_config.yml`:
```yml

```
