### PR TITLE
perf: Optimize comments.js file loading condition

### DIFF
--- a/layout/_scripts/index.njk
+++ b/layout/_scripts/index.njk
@@ -1,6 +1,6 @@
 {%- include 'vendors.njk' -%}
 
-{%- if theme.injects.comment.length > 0 %}
+{%- if theme.injects.comment.length > 1 %}
   {{- next_js('comments.js') }}
 {%- endif %}
 

--- a/layout/_scripts/index.njk
+++ b/layout/_scripts/index.njk
@@ -1,6 +1,8 @@
 {%- include 'vendors.njk' -%}
 
-{{- next_js('comments.js') }}
+{%- if theme.injects.comment.length > 0 %}
+  {{- next_js('comments.js') }}
+{%- endif %}
 
 {{- next_js('utils.js') }}
 {%- if theme.motion.enable %}


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. NexT includes 4 schemes: Muse and Mist have similar structure, but Pisces and Gemini are very different from them. It is possible that one scheme works fine after the changes, but another scheme is broken. Please make the tests in different schemes to make sure the changes are compatible with all schemes.

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] The changes have been tested (for bug fixes / features).
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [ ] Feature.
- [x] Improvement.
- [ ] Code style update (formatting, linting).
- [ ] Refactoring (no functional changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue resolved:

- The `source/js/comments.js` will included in html even if none of the comment systems is enabled.
- The `source/js/config.js` is inside the head tag, which will block the rendering, but it doesn't have to.

## What is the new behavior?

- The `source/js/comments.js` will not be included in html if none of the comment system is using.
- The `source/js/config.js` is now at the end of the body tag, right after the vendor scripts and before all the next script, which won't block the DOM rendering and everything works just like before.

### How to use?

Disable all the comment system or enable some of them in NexT `_config.yml`.