### PR TITLE
Add anchor support for  `hexo-renderer-pandoc` users

### DIFF
--- a/source/js/config.js
+++ b/source/js/config.js
@@ -64,3 +64,31 @@ if (!window.NexT) window.NexT = {};
     variableConfig = {};
   });
 })();
+
+document.addEventListener("page:loaded", function() {
+    // 获取所有标题元素
+    var headings = document.querySelectorAll("h1, h2, h3, h4, h5, h6");
+
+    // 遍历标题元素列表并为每个元素添加类名 "headerlink"
+    for (var i = 0; i < headings.length; i++) {
+      heading = headings[i];
+
+      id_text = heading.textContent;
+      id_text = id_text.replace(/\s/g, "-"); //把原文的空格替换成-. 暂时没有解决重名的问题.
+
+      // 创建超链接元素
+      var link = document.createElement("a");
+      link.classList.add("headerlink");//在CSS中, 具有headerlink类的元素会生成anchor.
+      link.href = "#" + id_text;//超链接指向的目的heading地址, 空格替换成-.
+      link.title = heading.textContent;//这是鼠标悬停到超链接时的提示信息, 不需要替换空格
+      link.setAttribute("aria-hidden", "true");
+
+      // 将超链接添加到标题元素的里面
+      heading.insertAdjacentElement("afterbegin", link);
+
+      heading.id = id_text;//heading的空格替换成-.
+    }
+  }
+);
+
+


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. NexT includes 4 schemes: Muse and Mist have similar structure, but Pisces and Gemini are very different from them. It is possible that one scheme works fine after the changes, but another scheme is broken. Please make the tests in different schemes to make sure the changes are compatible with all schemes.

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [ x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x ] The changes have been tested (for bug fixes / features).
- [x ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [ ] Feature.
- [ x] Improvement.
- [ ] Code style update (formatting, linting).
- [ ] Refactoring (no functional changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->
The "named anchor"  feature is only supported for 2 renderer plugins:
1. hexo-renderer-markdown-it 
2. hexo-renderer-marked

People using `hexo-renderer-pandoc` can't have anchor on their headings.

Issue resolved:
Now the `hexo-renderer-pandoc` user can have their anchors.


## What is the new behavior?
<!-- Description about this pull, in several words -->
I made changes to `<>/themes/hexo-theme-next/source/js/config.js`, add one eventlistener to make headings have hyperlinks with "headerlink" class. That's all.

As the css code in `<next theme>/source/css/_common/components/post/post-body.styl` shows. it'll render those elements with "herlerlink" or "header-anchor" class to anchors. 
But each of the 2 class attributes is from `hexo-renderer-markdown-it`, `hexo-renderer-marked`. So for pandoc users. the headings are simply "headings", there's no anchor for them.

Through the js code, i add the hyperlink element after the heading element and achieve the anchor feature.

Btw, by `hexo-renderer-markdown-it`, user can modify the "id" value of headings in the `next config` file. For example, they can replace the whitespaces with hypens for their heading's id:
```
"Header Anchor" -> "Header-Anchor"
```
Note that my transformation is case sensitive. You can easily change it.


- Screenshots with this changes:
Original:
<img width="839" alt="image" src="https://github.com/next-theme/hexo-theme-next/assets/74082944/8cefd96d-51e8-4214-8c5e-ca67122bb43c">

<img width="449" alt="image" src="https://github.com/next-theme/hexo-theme-next/assets/74082944/1a2e63be-8304-4ffc-911d-038ad7e0b343">


Add anchor:

<img width="803" alt="image" src="https://github.com/next-theme/hexo-theme-next/assets/74082944/5637c188-1239-47c7-b006-4f7510badb03">

<img width="404" alt="image" src="https://github.com/next-theme/hexo-theme-next/assets/74082944/7a879869-b6f5-4bc6-af8d-e0864563798b">



### How to use?

Since I only add one function to a js file.  There's litter difference. So you can simply  clone this commit and run it.

In NexT `_config.yml`:
The same as in official repo.
# Note
* I just add one function to `themes/hexo-theme-next/source/js/config.js` to achieve this. This is becaouse i don't know how Next invokes the js code (QAQ), so i can't write the code in a new separate file. For better modularization, this change should be migrated to the skeleton code. 

* Since people using the other 2 plugins already have changed their heading elements, this change doesn't apply to them, and may even lead to conflit. So it's orientated for pandoc users.

* Since the pandoc is [the only decent way](https://theme-next.js.org/docs/third-party-services/math-equations) to support mathjax in Next Theme. It's weird that it's pandoc users that can't have anchor feature. People have to make a choice between math supprt and anchor, which is sad. And since the [custom file feate](https://theme-next.js.org/docs/advanced-settings/custom-files) of Next don't support javascript change, the obly way people to achieve the feature is to change the js file in `<next>` folder, which is a gitsubmodule. This conflcts with the version control system. So i think the manstream must fix this problem even if my code be rejected.