### PR TITLE
Support folding code blocks in tabs

### DIFF
--- a/source/js/next-boot.js
+++ b/source/js/next-boot.js
@@ -29,6 +29,10 @@ NexT.boot.registerEvents = function() {
       target && target.click();
     }
   });
+
+  window.addEventListener('tabs:click', e => {
+    NexT.utils.registerCodeblock(e.target);
+  });
 };
 
 NexT.boot.refresh = function() {

--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -39,24 +39,27 @@ NexT.utils = {
     });
   },
 
-  registerCodeblock: function() {
-    let figure = document.querySelectorAll('figure.highlight');
+  registerCodeblock: function(element) {
+    const inited = !!element;
+    let figure = (inited ? element : document).querySelectorAll('figure.highlight');
     let isHljsWithWrap = true;
     if (figure.length === 0) {
       figure = document.querySelectorAll('pre:not(.mermaid)');
       isHljsWithWrap = false;
     }
     figure.forEach(element => {
-      let span = element.querySelectorAll('.code .line span');
-      if (span.length === 0) {
-        // Hljs without line_number and wrap
-        span = element.querySelectorAll('code.highlight span');
-      }
-      span.forEach(s => {
-        s.classList.forEach(name => {
-          s.classList.replace(name, `hljs-${name}`);
+      if (!inited) {
+        let span = element.querySelectorAll('.code .line span');
+        if (span.length === 0) {
+          // Hljs without line_number and wrap
+          span = element.querySelectorAll('code.highlight span');
+        }
+        span.forEach(s => {
+          s.classList.forEach(name => {
+            s.classList.replace(name, `hljs-${name}`);
+          });
         });
-      });
+      }
       const height = parseInt(window.getComputedStyle(element).height.replace('px', ''), 10);
       const needFold = CONFIG.fold.enable && (height > CONFIG.fold.height);
       if (!needFold && !CONFIG.copycode.enable) return;
@@ -64,22 +67,26 @@ NexT.utils = {
       if (isHljsWithWrap && CONFIG.copycode.style === 'mac') {
         target = element;
       } else {
-        // https://github.com/next-theme/hexo-theme-next/issues/98
-        // https://github.com/next-theme/hexo-theme-next/pull/508
-        const container = element.querySelector('.table-container') || element;
-        const box = document.createElement('div');
-        box.className = 'code-container';
-        container.wrap(box);
+        let box = element.querySelector('.code-container');
+        if (!box) {
+          // https://github.com/next-theme/hexo-theme-next/issues/98
+          // https://github.com/next-theme/hexo-theme-next/pull/508
+          const container = element.querySelector('.table-container') || element;
+          box = document.createElement('div');
+          box.className = 'code-container';
+          container.wrap(box);
+        }
         target = box;
       }
-      if (needFold) {
+      if (needFold && !target.classList.contains('unfold')) {
         target.classList.add('highlight-fold');
         target.insertAdjacentHTML('beforeend', '<div class="fold-cover"></div><div class="expand-btn"><i class="fa fa-angle-down fa-fw"></i></div>');
         target.querySelector('.expand-btn').addEventListener('click', () => {
           target.classList.remove('highlight-fold');
+          target.classList.add('unfold');
         });
       }
-      if (!CONFIG.copycode.enable) return;
+      if (inited || !CONFIG.copycode.enable) return;
       // One-click copy code support.
       target.insertAdjacentHTML('beforeend', '<div class="copy-btn"><i class="fa fa-copy fa-fw"></i></div>');
       const button = target.querySelector('.copy-btn');


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] The changes have been tested (for bug fixes / features).
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).

## PR Type

- [ ] Bugfix.
- [x] Feature.
- [ ] Improvement.
- [ ] Code style update (formatting, linting).
- [ ] Refactoring (no functional changes).
- [ ] Documentation.
- [ ] Translation.
- [ ] Other... Please describe:

## What is the current behavior?

Non-default tab is not folded.
See also #679.

## What is the new behavior?

Non-default tab is folded on the fly based on the event dispatched when user switch to a new tab.

- Link to demo site with this changes: <https://peichengliu.github.io/kuangbin/kuangbin-%E4%B8%93%E9%A2%98%E5%9B%9B-%E6%9C%80%E7%9F%AD%E8%B7%AF%E7%BB%83%E4%B9%A0/>
- Screenshots with this changes:

### How to use?

In NexT `_config.yml`:
```yml
codeblock:
  # Fold code block
  fold:
    enable: true
    threshold: 500
```
