### PR TITLE
Fixed a bug where the SRI hash in _vendors.yml is incorrect

### DIFF
--- a/_vendors.yml
+++ b/_vendors.yml
@@ -5,7 +5,7 @@ anime:
   name: animejs
   version: 3.2.2
   file: lib/anime.min.js
-  integrity: sha256-tc4b48P1MPGS4PJXHRlChGCW1mEZy62jS/3JEsSHPzU=
+  integrity: sha256-vO75T5ZEgfdoDZXn+75ajCDTlFqSanVIdImKV423x6s=
 fontawesome:
   name: '@fortawesome/fontawesome-free'
   version: 6.5.0


### PR DESCRIPTION
Fixed a bug where the SRI hash is incorrect.

<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. NexT includes 4 schemes: Muse and Mist have similar structure, but Pisces and Gemini are very different from them. It is possible that one scheme works fine after the changes, but another scheme is broken. Please make the tests in different schemes to make sure the changes are compatible with all schemes.

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] The changes have been tested (for bug fixes / features).
- [x] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Improvement.
- [ ] Code style update (formatting, linting).
- [ ] Refactoring (no functional changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->
https://theme-next.js.org/

The website can not display the content, and the console send an error message.
```
None of the “sha256” hashes in the integrity attribute match the content of the subresource. The computed hash is “vO75T5ZEgfdoDZXn+75ajCDTlFqSanVIdImKV423x6s=”.
```
Issue resolved:
After checking the page source code, I found there is a mistake with "https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.2/anime.min.js" hash value. Then I change it from "sha256-tc4b48P1MPGS4PJXHRlChGCW1mEZy62jS/3JEsSHPzU=" to "sha256-vO75T5ZEgfdoDZXn+75ajCDTlFqSanVIdImKV423x6s=", it works.


## What is the new behavior?
<!-- Description about this pull, in several words -->

The website can display content after using the correct SRI hash value.


