### PR TITLE
Add unit test for integrity

### DIFF
--- a/test/validate/index.js
+++ b/test/validate/index.js
@@ -13,19 +13,19 @@ describe('Validate', () => {
     });
   });
 
-  it('vendors', async () => {
+  it('vendors', async() => {
     const { createHash } = require('crypto');
     const { getVendors } = require('../../scripts/events/lib/utils');
     const vendorsFile = fs.readFileSync(path.join(__dirname, '../../_vendors.yml'));
-    (await Promise.all(Object.entries(yaml.load(vendorsFile)).map(async ([key, vendor]) => {
+    (await Promise.all(Object.entries(yaml.load(vendorsFile)).map(async([key, vendor]) => {
       vendor.minified = vendor.file || '';
       const { cdnjs } = getVendors(vendor);
       // fetch content and check sha256
       return await fetch(cdnjs)
-        .then((response) => response.text())
-        .then((body) => {
+        .then(response => response.text())
+        .then(body => {
           const integrity = Buffer.from(createHash('sha256').update(body, 'utf8').digest()).toString('base64');
-          return !vendor.integrity || "sha256-" + integrity == vendor.integrity;
+          return !vendor.integrity || 'sha256-' + integrity === vendor.integrity;
         });
     }))).should.all.equal(true);
   });

--- a/test/validate/index.js
+++ b/test/validate/index.js
@@ -27,7 +27,7 @@ describe('Validate', () => {
           const integrity = Buffer.from(createHash('sha256').update(body, 'utf8').digest()).toString('base64');
           return !vendor.integrity || 'sha256-' + integrity === vendor.integrity;
         });
-    }))).should.all.equal(true);
+    })))[0].should.all.equal(true);
   });
 
   it('language', () => {

--- a/test/validate/index.js
+++ b/test/validate/index.js
@@ -13,11 +13,21 @@ describe('Validate', () => {
     });
   });
 
-  it('vendors', () => {
+  it('vendors', async () => {
+    const { createHash } = require('crypto');
+    const { getVendors } = require('../../scripts/events/lib/utils');
     const vendorsFile = fs.readFileSync(path.join(__dirname, '../../_vendors.yml'));
-    should.not.throw(() => {
-      yaml.load(vendorsFile);
-    });
+    (await Promise.all(Object.entries(yaml.load(vendorsFile)).map(async ([key, vendor]) => {
+      vendor.minified = vendor.file || '';
+      const { cdnjs } = getVendors(vendor);
+      // fetch content and check sha256
+      return await fetch(cdnjs)
+        .then((response) => response.text())
+        .then((body) => {
+          const integrity = Buffer.from(createHash('sha256').update(body, 'utf8').digest()).toString('base64');
+          return !vendor.integrity || "sha256-" + integrity == vendor.integrity;
+        });
+    }))).should.all.equal(true);
   });
 
   it('language', () => {


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. NexT includes 4 schemes: Muse and Mist have similar structure, but Pisces and Gemini are very different from them. It is possible that one scheme works fine after the changes, but another scheme is broken. Please make the tests in different schemes to make sure the changes are compatible with all schemes.

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] The changes have been tested (for bug fixes / features).
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [ ] Feature.
- [ ] Improvement.
- [ ] Code style update (formatting, linting).
- [ ] Refactoring (no functional changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [x] Other... Please describe: unit test

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

The test is expected to fail due to https://github.com/next-theme/hexo-theme-next/issues/728.

## What is the new behavior?
<!-- Description about this pull, in several words -->

- Link to demo site with this changes:
- Screenshots with this changes:

### How to use?

In NexT `_config.yml`:
```yml

```
