### PR TITLE
Feat: Add notranslate to prevent translating code

### DIFF
--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -75,6 +75,9 @@ NexT.utils = {
           box = document.createElement('div');
           box.className = 'code-container';
           container.wrap(box);
+
+          // add "notranslate" to prevent Google Translate from translating it, which also completely messes up the layout
+          box.classList.add('notranslate');
         }
         target = box;
       }


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. NexT includes 4 schemes: Muse and Mist have similar structure, but Pisces and Gemini are very different from them. It is possible that one scheme works fine after the changes, but another scheme is broken. Please make the tests in different schemes to make sure the changes are compatible with all schemes.

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [ ] The changes have been tested (for bug fixes / features).
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [ ] Feature.
- [x] Improvement.
- [ ] Code style update (formatting, linting).
- [ ] Refactoring (no functional changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

When translating using Google Translate, code blocks will be significantly messed up.

For example: [original](https://blog.maple3142.net/2024/01/11/seccon-ctf-2023-final-writeups/) -> [translate (jp)](https://blog-maple3142-net.translate.goog/2024/01/11/seccon-ctf-2023-final-writeups/?_x_tr_sl=auto&_x_tr_tl=ja&_x_tr_hl=zh-TW&_x_tr_pto=wapp)

![image](https://github.com/next-theme/hexo-theme-next/assets/9370547/2be4bc99-c41a-49c6-8dc5-d9b05cce0843)

## What is the new behavior?
<!-- Description about this pull, in several words -->

code blocks will not be translated:

- Link to demo site with this changes:
- Screenshots with this changes:

![image](https://github.com/next-theme/hexo-theme-next/assets/9370547/5467ac8f-6797-4558-adbd-beefce57006f)

### How to use?

No need to change anything