### PR TITLE
Fix utterances/giscus with pjax

### DIFF
--- a/source/js/pjax.js
+++ b/source/js/pjax.js
@@ -3,6 +3,7 @@
 const pjax = new Pjax({
   selectors: [
     'head title',
+    'meta[property="og:title"]',
     'script[type="application/json"]',
     // Precede .main-inner to prevent placeholder TOC changes asap
     '.post-toc-wrap',


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. NexT includes 4 schemes: Muse and Mist have similar structure, but Pisces and Gemini are very different from them. It is possible that one scheme works fine after the changes, but another scheme is broken. Please make the tests in different schemes to make sure the changes are compatible with all schemes.

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/next-theme/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] The changes have been tested (for bug fixes / features).
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Improvement.
- [ ] Code style update (formatting, linting).
- [ ] Refactoring (no functional changes).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue resolved:

If we use utterances or giscus comment system with pjax enabled, and use 'og:title' to map blog post with issue or discussion, then the comment does not load correctly if we change to another page. The reason is that utterance/giscus will consult `<meta property="og:title" content="***">` in the head, which is not reloaded by pjax. The the comment shown is actually comments for the last page.

## What is the new behavior?
<!-- Description about this pull, in several words -->

The meta tag for 'og:title' is reloaded by pjax, and comments are load correctly.
