### PR TITLE
fix: support dark mode for note tags in modern style

### DIFF
--- a/source/css/_common/scaffolding/tags/note.styl
+++ b/source/css/_common/scaffolding/tags/note.styl
@@ -88,9 +88,9 @@ if (hexo-config('note.style') != 'disabled') {
 
           if (hexo-config('darkmode')) {
             @media (prefers-color-scheme: dark) {
-              background: $note-modern-bg-dark[$type]
-              border-color: $note-modern-border-dark[$type]
-              color: $note-modern-text-dark[$type]
+              background: $note-modern-bg-dark[$type];
+              border-color: $note-modern-border-dark[$type];
+              color: $note-modern-text-dark[$type];
 
               a:not(.btn) {
                 border-bottom-color: $note-modern-text-dark[$type];

--- a/source/css/_common/scaffolding/tags/note.styl
+++ b/source/css/_common/scaffolding/tags/note.styl
@@ -85,6 +85,24 @@ if (hexo-config('note.style') != 'disabled') {
               color: $note-modern-hover[$type];
             }
           }
+
+          if (hexo-config('darkmode')) {
+            @media (prefers-color-scheme: dark) {
+              background: $note-modern-bg-dark[$type]
+              border-color: $note-modern-border-dark[$type]
+              color: $note-modern-text-dark[$type]
+
+              a:not(.btn) {
+                border-bottom-color: $note-modern-text-dark[$type];
+                color: $note-modern-text-dark[$type];
+
+                &:hover {
+                  border-bottom-color: $note-modern-hover-dark[$type];
+                  color: $note-modern-hover-dark[$type];
+                }
+              }
+            }
+          }
         }
 
         if ($note-style != 'modern') {

--- a/source/css/_variables/base.styl
+++ b/source/css/_variables/base.styl
@@ -374,11 +374,14 @@ $note-modern-hover = {
   danger  : darken(spin($note-modern-text.danger, -10), 22%)
 };
 
-transform-map(map, transform)
-  new-map = {};
-  for key, val in map
+transform-map(map, transform) {
+  new-map = {
+  }
+  for key, val in map {
     new-map[key] = transform(val);
+  }
   return new-map;
+}
 
 $note-modern-border-dark = transform-map($note-modern-hover,  @(val) {           lighten(val, 10%)       });
 $note-modern-bg-dark     = transform-map($note-modern-text,   @(val) { desaturate(darken(val, 20%), 20%) });

--- a/source/css/_variables/base.styl
+++ b/source/css/_variables/base.styl
@@ -374,6 +374,16 @@ $note-modern-hover = {
   danger  : darken(spin($note-modern-text.danger, -10), 22%)
 };
 
+transform-map(map, transform)
+  new-map = {};
+  for key, val in map
+    new-map[key] = transform(val);
+  return new-map;
+
+$note-modern-border-dark = transform-map($note-modern-hover,  @(val) {           lighten(val, 10%)       });
+$note-modern-bg-dark     = transform-map($note-modern-text,   @(val) { desaturate(darken(val, 20%), 20%) });
+$note-modern-text-dark   = transform-map($note-modern-bg,     @(val) {            darken(val, 10%)       });
+$note-modern-hover-dark  = transform-map($note-modern-border, @(val) {           lighten(val, 75%)       });
 
 // Tabs border radius
 // --------------------------------------------------


### PR DESCRIPTION
## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Remove items that do not apply. For completed items, change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The changes have been tested (for bug fixes / features).
- [x] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [ ] Feature.
- [x] Improvement.
- [ ] Code style update (e.g. formatting, linting).
- [ ] Refactoring (no changes to functionality and APIs).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations: https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?

No dark color maps are specified for notes in modern style, which looks bad. See #513

## What is the new behavior?

<img width="844" alt="image" src="https://github.com/user-attachments/assets/2dc596af-1b7f-4943-9152-46ff9055342e">

- `$notes-modern-{bg,text,border,hover}-dark` are added
- I simply exchanged `bg` with `text`, `hover` with `border`, and did some adjustments in lightness and saturation. Which is not perfect but acceptable in my opinion. Plus the code looks kinda elegant?

### How to use?

In NexT `_config.yml`:
```yml
note:
  style: modern
```
