### PR TITLE
improvement: Add dark color scheme for text selection

### DIFF
--- a/source/css/_colors.styl
+++ b/source/css/_colors.styl
@@ -3,6 +3,8 @@
   --content-bg-color: $content-bg-color;
   --card-bg-color: $card-bg-color;
   --text-color: $text-color;
+  --selection-bg: $selection-bg;
+  --selection-color: $selection-color;
   --blockquote-color: $blockquote-color;
   --link-color: $link-color;
   --link-hover-color: $link-hover-color;
@@ -35,6 +37,8 @@ if (hexo-config('darkmode')) {
       --content-bg-color: $content-bg-color-dark;
       --card-bg-color: $card-bg-color-dark;
       --text-color: $text-color-dark;
+      --selection-bg: $selection-bg-dark;
+      --selection-color: $selection-color-dark;
       --blockquote-color: $blockquote-color-dark;
       --link-color: $link-color-dark;
       --link-hover-color: $link-hover-color-dark;

--- a/source/css/_common/scaffolding/base.styl
+++ b/source/css/_common/scaffolding/base.styl
@@ -1,6 +1,6 @@
 ::selection {
-  background: $selection-bg;
-  color: $selection-color;
+  background: var(--selection-bg);
+  color: var(--selection-color);
 }
 
 html, body {

--- a/source/css/_variables/base.styl
+++ b/source/css/_variables/base.styl
@@ -59,6 +59,8 @@ $content-bg-color-dark        = $black-dim;
 // Selection
 $selection-bg                 = $blue-deep;
 $selection-color              = $gainsboro;
+$selection-bg-dark            = $grey;
+$selection-color-dark         = $black-dim;
 
 // Dark mode color
 $card-bg-color                = $whitesmoke;


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to NexT code! Before you open the pull request, please:

1. Make the tests to confirm that the changes are compatible with PJAX, Dark Mode and all four schemes of NexT (Muse, Mist, Pisces and Gemini). For backend code changes, modify or add unit tests if necessary.

2. Break up your pull request into multiple smaller requests if it contains multiple bug fixes or new features. Each pull request should have one bug fix or new feature only for better code maintainability.

3. If possible, please write the pull request description in English.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Remove items that do not apply. For completed items, change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The changes have been tested (for bug fixes / features).
- [x] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [ ] Feature.
- [x] Improvement.
- [ ] Code style update (e.g. formatting, linting).
- [ ] Refactoring (no changes to functionality and APIs).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations: https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?

Text selection is unreadable in dark mode.

## What is the new behavior?

<img width="962" alt="image" src="https://github.com/user-attachments/assets/5560c2c6-3282-417b-9dc0-023bb547c8d3">

### How to use?

In NexT `_config.yml`:
```yml

```
