### PR TITLE
Supports customizing the width of the follow-me QR code

### DIFF
--- a/source/css/_common/components/post/post-followme.styl
+++ b/source/css/_common/components/post/post-followme.styl
@@ -47,9 +47,10 @@ if (hexo-config('follow_me')) {
       .social-item-img {
         display: none;
         left: 50%;
-        max-width: $post-reward-img-width;
+        max-width: $post-followme-img-width;
         position: absolute;
         transform: translate(-50%, 20px);
+        z-index: 1;
       }
     }
   }

--- a/source/css/_variables/base.styl
+++ b/source/css/_variables/base.styl
@@ -292,6 +292,7 @@ $post-eof-margin-bottom       = 60px; //  or 120px for less white space;
 
 $post-card-margin             = 1em 0 0;
 $post-reward-img-width        = 180px;
+$post-followme-img-width      = 460px;
 
 
 // Note colors

--- a/source/css/_variables/base.styl
+++ b/source/css/_variables/base.styl
@@ -292,7 +292,7 @@ $post-eof-margin-bottom       = 60px; //  or 120px for less white space;
 
 $post-card-margin             = 1em 0 0;
 $post-reward-img-width        = 180px;
-$post-followme-img-width      = 460px;
+$post-followme-img-width      = $post-reward-img-width;
 
 
 // Note colors


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to NexT code! Before you open the pull request, please:

1. Make the tests to confirm that the changes are compatible with PJAX, Dark Mode and all four schemes of NexT (Muse, Mist, Pisces and Gemini). For backend code changes, modify or add unit tests if necessary.

2. Break up your pull request into multiple smaller requests if it contains multiple bug fixes or new features. Each pull request should have one bug fix or new feature only for better code maintainability.

3. If possible, please write the pull request description in English.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Remove items that do not apply. For completed items, change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The changes have been tested (for bug fixes / features).
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [ ] Feature.
- [x] Improvement.
- [ ] Code style update (e.g. formatting, linting).
- [ ] Refactoring (no changes to functionality and APIs).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations: https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->
Under the current configuration, the WeChat QR code image is too small and cannot be scanned:
![image-20240831204940929](https://github.com/user-attachments/assets/6d4d1f56-fcea-4fbe-97d9-a14f70d7e99a)

When setting a larger max-width value, the following issues occur：
![image-20240831212046068](https://github.com/user-attachments/assets/8a75d01b-abbf-4d32-9540-0d0d64afa6a1)
![image-20240831212708999](https://github.com/user-attachments/assets/76c10664-03a2-461e-9dc2-192b4522c77d)

Because AddToAny Share button appears on top layer：
![image-20240831212018720](https://github.com/user-attachments/assets/9d652b75-3fb9-49de-82cc-c0033095c10a)

Similarly, the comment component also prevents the WeChat QR code from displaying fully：
![image-20240901083926322](https://github.com/user-attachments/assets/b2135946-d485-47ba-af6c-2958bdbdb36e)


Issue resolved:

## What is the new behavior?
<!-- Please describe the new behavior of this pull request -->
Improvement:
![Snipaste_2024-09-01_10-30-48](https://github.com/user-attachments/assets/05c40096-fe18-456f-b9c6-ea718baf746b)
![image-20240901084257134](https://github.com/user-attachments/assets/eca0f4de-c51a-4b51-80b5-027b0e52b1e7)

- Link to demo site with this changes: https://nobug.world/blogs/21720/
- Screenshots with this changes:

### How to use?

In NexT `_config.yml`:
```yml

```
