### PR TITLE
Use calc-size in `.active > .nav-child`

### DIFF
--- a/source/css/_common/outline/sidebar/sidebar-toc.styl
+++ b/source/css/_common/outline/sidebar/sidebar-toc.styl
@@ -34,19 +34,17 @@ if (hexo-config('toc.enable')) {
     .nav {
       if (not hexo-config('toc.expand_all')) {
         .nav-child {
-          --height: 0;
           height: 0;
           opacity: 0;
           overflow: hidden;
-          transition-property: height, opacity, visibility;
+          transition-property: height, opacity;
           transition: $transition-ease;
-          visibility: hidden;
         }
 
         .active > .nav-child {
-          height: var(--height, auto);
+          height: auto;
+          height: calc-size(auto, size);
           opacity: 1;
-          visibility: unset;
         }
       }
 

--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -352,24 +352,16 @@ NexT.utils = {
     const target = navItemList[index];
     if (!target || target.classList.contains('active-current')) return;
 
-    const singleHeight = navItemList[navItemList.length - 1].offsetHeight;
-
     nav.querySelectorAll('.active').forEach(navItem => {
       navItem.classList.remove('active', 'active-current');
     });
     target.classList.add('active', 'active-current');
 
     let activateEle = target.querySelector('.nav-child') || target.parentElement;
-    let navChildHeight = 0;
 
     while (nav.contains(activateEle)) {
       if (activateEle.classList.contains('nav-item')) {
         activateEle.classList.add('active');
-      } else { // .nav-child or .nav
-        // scrollHeight isn't reliable for transitioning child items.
-        // The last nav-item in a list has a margin-bottom of 5px.
-        navChildHeight += (singleHeight * activateEle.childElementCount) + 5;
-        activateEle.style.setProperty('--height', `${navChildHeight}px`);
       }
       activateEle = activateEle.parentElement;
     }
@@ -408,16 +400,8 @@ NexT.utils = {
     const tocPanel = panelContainer.firstElementChild;
     const overviewPanel = panelContainer.lastElementChild;
 
-    let postTOCHeight = tocPanel.scrollHeight;
-    // For TOC activation, try to use the animated TOC height
-    if (index === 0) {
-      const nav = tocPanel.querySelector('.nav');
-      if (nav) {
-        postTOCHeight = parseInt(nav.style.getPropertyValue('--height'), 10);
-      }
-    }
     const panelHeights = [
-      postTOCHeight,
+      tocPanel.scrollHeight,
       overviewPanel.scrollHeight
     ];
     panelContainer.style.setProperty('--inactive-panel-height', `${panelHeights[1 - index]}px`);


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to NexT code! Before you open the pull request, please:

1. Make the tests to confirm that the changes are compatible with PJAX, Dark Mode and all four schemes of NexT (Muse, Mist, Pisces and Gemini). For backend code changes, modify or add unit tests if necessary.

2. Break up your pull request into multiple smaller requests if it contains multiple bug fixes or new features. Each pull request should have one bug fix or new feature only for better code maintainability.

3. If possible, please write the pull request description in English.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Remove items that do not apply. For completed items, change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The changes have been tested (for bug fixes / features).
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [ ] Feature.
- [x] Improvement.
- [ ] Code style update (e.g. formatting, linting).
- [ ] Refactoring (no changes to functionality and APIs).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations: https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

#323 introduced a transition animation for TOC, and due to the need to calculate heights, the author @PaperStrike wrote the algorithm in JavaScript. However, it is not accurate when encountering collapsed rows (#772) and no better solution has been found. I noticed that this issue might be resolved using the newly introduced `calc-size` in CSS, but it is currently only supported by Chrome and Edge versions 129 and above. We may need to wait until it is supported by other mainstream browsers (such as Safari and Firefox) before merging. You are welcome to test the TOC animation effects on the latest versions of Chrome and Edge.

Issue resolved:

## What is the new behavior?
<!-- Please describe the new behavior of this pull request -->

- Link to demo site with this changes:
- Screenshots with this changes:

### How to use?

In NexT `_config.yml`:
```yml

```
