### PR TITLE
Fix SCRIPT1028 caused by async

### DIFF
--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -449,7 +449,6 @@ NexT.utils = {
       condition = false,
       attributes: {
         id = '',
-        async = false,
         defer = false,
         crossOrigin = '',
         dataset = {},
@@ -457,6 +456,7 @@ NexT.utils = {
       } = {},
       parentNode = null
     } = options;
+    const async = options.async ?? false;
     return new Promise((resolve, reject) => {
       if (condition) {
         resolve();


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to NexT code! Before you open the pull request, please:

1. Make the tests to confirm that the changes are compatible with PJAX, Dark Mode and all four schemes of NexT (Muse, Mist, Pisces and Gemini). For backend code changes, modify or add unit tests if necessary.

2. Break up your pull request into multiple smaller requests if it contains multiple bug fixes or new features. Each pull request should have one bug fix or new feature only for better code maintainability.

3. If possible, please write the pull request description in English.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Remove items that do not apply. For completed items, change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The changes have been tested (for bug fixes / features).
- [x] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Improvement.
- [ ] Code style update (e.g. formatting, linting).
- [ ] Refactoring (no changes to functionality and APIs).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations: https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?

Issue resolved:

On Edge HTML writting like
```js
const { async = false } = {}
```
will cause `Expected identifier, string or number`.

![image](https://github.com/user-attachments/assets/f54c63c7-c211-4e5f-836c-6d8587270103)

And it cannot be fixed by babel.

So just change it to
```js
const async = a.async ?? false;
```
and it works fine.