### PR TITLE
Add supports for light-dark

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,6 +45,12 @@ scheme: Muse
 # Dark Mode
 darkmode: false
 
+# Light-Dark Mode
+lightdark:
+  enable: false
+  # Add @supports (color: light-dark(red, red)) check
+  check_supports: true
+
 
 # ---------------------------------------------------------------
 # Site Information Settings

--- a/source/css/_colors.styl
+++ b/source/css/_colors.styl
@@ -77,3 +77,46 @@ if (hexo-config('darkmode')) {
     }
   }
 }
+
+if (hexo-config('lightdark.enable')) {
+  +light-dark-block() {
+    :root {
+      --body-bg-color: light-dark($body-bg-color, $body-bg-color-dark);
+      --content-bg-color: light-dark($content-bg-color, $content-bg-color-dark);
+      --card-bg-color: light-dark($card-bg-color, $card-bg-color-dark);
+      --text-color: light-dark($text-color, $text-color-dark);
+      --selection-bg: light-dark($selection-bg, $selection-bg-dark);
+      --selection-color: light-dark($selection-color, $selection-color-dark);
+      --blockquote-color: light-dark($blockquote-color, $blockquote-color-dark);
+      --link-color: light-dark($link-color, $link-color-dark);
+      --link-hover-color: light-dark($link-hover-color, $link-hover-color-dark);
+      --brand-color: light-dark($brand-color, $brand-color-dark);
+      --brand-hover-color: light-dark($brand-hover-color, $brand-hover-color-dark);
+      --table-row-odd-bg-color: light-dark($table-row-odd-bg-color, $table-row-odd-bg-color-dark);
+      --table-row-hover-bg-color: light-dark($table-row-hover-bg-color, $table-row-hover-bg-color-dark);
+      --menu-item-bg-color: light-dark($menu-item-bg-color, $menu-item-bg-color-dark);
+      --theme-color: light-dark($theme-color, $theme-color-dark);
+
+      --btn-default-bg: light-dark($btn-default-bg, $btn-default-bg-dark);
+      --btn-default-color: light-dark($btn-default-color, $btn-default-color-dark);
+      --btn-default-border-color: light-dark($btn-default-border-color, $btn-default-border-color-dark);
+      --btn-default-hover-bg: light-dark($btn-default-hover-bg, $btn-default-hover-bg-dark);
+      --btn-default-hover-color: light-dark($btn-default-hover-color, $btn-default-hover-color-dark);
+      --btn-default-hover-border-color: light-dark($btn-default-hover-border-color, $btn-default-hover-border-color-dark);
+
+      color-scheme: light dark;
+
+      img {
+        opacity: light-dark(1, .75);
+
+        &:hover {
+          opacity: light-dark(1, .9);
+        }
+      }
+
+      iframe {
+        color-scheme: light;
+      }
+    }
+  }
+}

--- a/source/css/_common/components/pages/tag-cloud.styl
+++ b/source/css/_common/components/pages/tag-cloud.styl
@@ -26,3 +26,16 @@ if (hexo-config('darkmode')) {
     }
   }
 }
+
+if (hexo-config('lightdark.enable')) {
+  +light-dark-block() {
+    for $tag-cloud in (0 .. 10) {
+      $tag-cloud-color = mix($tag-cloud-end, $tag-cloud-start, $tag-cloud * 10);
+      $tag-cloud-color-dark = mix($tag-cloud-end-dark, $tag-cloud-start-dark, $tag-cloud * 10);
+      .tag-cloud-{$tag-cloud} {
+        border-bottom-color: light-dark($tag-cloud-color, $tag-cloud-color-dark);
+        color: light-dark($tag-cloud-color, $tag-cloud-color-dark);
+      }
+    }
+  }
+}

--- a/source/css/_common/components/third-party/disqusjs.styl
+++ b/source/css/_common/components/third-party/disqusjs.styl
@@ -1,39 +1,48 @@
-if (hexo-config('disqusjs.enable') and hexo-config('darkmode')) {
-  @media (prefers-color-scheme:dark) {
-    html #dsqjs a {
-      color: var(--link-color);
-    }
+if (hexo-config('disqusjs.enable')) {
+  html #dsqjs {
+    color-scheme: light;
+  }
+  if (hexo-config('darkmode')) {
+    @media (prefers-color-scheme:dark) {
+      html #dsqjs {
+        color-scheme: dark;
+      }
 
-    html #dsqjs a:focus,html #dsqjs a:hover {
-      color: var(--link-hover-color);
-    }
+      html #dsqjs a {
+        color: var(--link-color);
+      }
 
-    html #dsqjs .dsqjs-nav,html #dsqjs footer {
-      border-color: var(--card-bg-color);
-    }
+      html #dsqjs a:focus,html #dsqjs a:hover {
+        color: var(--link-hover-color);
+      }
 
-    html #dsqjs .dsqjs-load-more,html #dsqjs .dsqjs-load-more:hover,html #dsqjs .dsqjs-nav-tab,html #dsqjs .dsqjs-no-comment,html #dsqjs .dsqjs-post-content {
-      color: var(--text-color);
-    }
+      html #dsqjs .dsqjs-nav,html #dsqjs footer {
+        border-color: var(--card-bg-color);
+      }
 
-    html #dsqjs .dsqjs-order-label {
-      background-color: #3e4b5e;
-    }
+      html #dsqjs .dsqjs-load-more,html #dsqjs .dsqjs-load-more:hover,html #dsqjs .dsqjs-nav-tab,html #dsqjs .dsqjs-no-comment,html #dsqjs .dsqjs-post-content {
+        color: var(--text-color);
+      }
 
-    html #dsqjs .dsqjs-order-radio:checked+.dsqjs-order-label {
-      background-color: var(--content-bg-color);
-    }
+      html #dsqjs .dsqjs-order-label {
+        background-color: #3e4b5e;
+      }
 
-    html #dsqjs .dsqjs-tab-active>span:after {
-      background-color: #2e9fff!important;
-    }
+      html #dsqjs .dsqjs-order-radio:checked+.dsqjs-order-label {
+        background-color: var(--content-bg-color);
+      }
 
-    html #dsqjs .dsqjs-footer,html #dsqjs .dsqjs-meta {
-      color: var(--text-color);
-    }
+      html #dsqjs .dsqjs-tab-active>span:after {
+        background-color: #2e9fff!important;
+      }
 
-    html #dsqjs .dsqjs-post-body blockquote {
-      border-color: var(--content-bg-color);
+      html #dsqjs .dsqjs-footer,html #dsqjs .dsqjs-meta {
+        color: var(--text-color);
+      }
+
+      html #dsqjs .dsqjs-post-body blockquote {
+        border-color: var(--content-bg-color);
+      }
     }
   }
 }

--- a/source/css/_common/components/third-party/gitalk.styl
+++ b/source/css/_common/components/third-party/gitalk.styl
@@ -14,4 +14,12 @@ if (hexo-config('gitalk.enable')) {
       }
     }
   }
+
+  if (hexo-config('lightdark.enable')) {
+    +light-dark-block() {
+      .gt-container .gt-header-textarea {
+        background-color: light-dark(#f6f6f6, var(--card-bg-color-dark)) !important;
+      }
+    }
+  }
 }

--- a/source/css/_common/components/third-party/search.styl
+++ b/source/css/_common/components/third-party/search.styl
@@ -62,6 +62,11 @@ if (hexo-config('local_search.enable') or hexo-config('algolia_search.enable')) 
           background: $grey-dim;
         }
       }
+      if (hexo-config('lightdark.enable')) {
+        +light-dark-block() {
+          background: light-dark($gainsboro, $grey-dim);
+        }
+      }
       border-top-left-radius: 5px;
       border-top-right-radius: 5px;
       display: flex;

--- a/source/css/_common/scaffolding/highlight/index.styl
+++ b/source/css/_common/scaffolding/highlight/index.styl
@@ -75,6 +75,14 @@ figure.highlight {
   overflow: auto;
   position: relative;
 
+  color-scheme: light;
+
+  if (hexo-config('darkmode')) {
+    @media (prefers-color-scheme: dark) {
+      color-scheme: dark;
+    }
+  }
+
   pre {
     border: 0;
     margin: 0;

--- a/source/css/_common/scaffolding/tags/note.styl
+++ b/source/css/_common/scaffolding/tags/note.styl
@@ -69,6 +69,11 @@ if (hexo-config('note.style') != 'disabled') {
               background: mix($note-bg[$type], $body-bg-color-dark, 10%);
             }
           }
+          if (hexo-config('lightdark.enable')) {
+            +light-dark-block() {
+              background: light-dark($note-bg[$type], mix($note-bg[$type], $body-bg-color-dark, 10%));
+            }
+          }
         }
 
         if ($note-style == 'modern') {
@@ -99,6 +104,24 @@ if (hexo-config('note.style') != 'disabled') {
                 &:hover {
                   border-bottom-color: $note-modern-hover-dark[$type];
                   color: $note-modern-hover-dark[$type];
+                }
+              }
+            }
+          }
+
+          if (hexo-config('lightdark.enable')) {
+            +light-dark-block() {
+              background: light-dark($note-modern-bg[$type], $note-modern-bg-dark[$type]);
+              border-color: light-dark($note-modern-border[$type], $note-modern-border-dark[$type]);
+              color: light-dark($note-modern-text[$type], $note-modern-text-dark[$type]);
+
+              a:not(.btn) {
+                border-bottom-color: light-dark($note-modern-text[$type], $note-modern-text-dark[$type]);
+                color: light-dark($note-modern-text[$type], $note-modern-text-dark[$type]);
+
+                &:hover {
+                  border-bottom-color: light-dark($note-modern-hover[$type], $note-modern-hover-dark[$type]);
+                  color: light-dark($note-modern-hover[$type], $note-modern-hover-dark[$type]);
                 }
               }
             }

--- a/source/css/_mixins.styl
+++ b/source/css/_mixins.styl
@@ -52,6 +52,17 @@ desktop-largest() {
   }
 }
 
+light-dark-block() {
+  if (hexo-config('lightdark.check_supports')){
+    @supports (color: light-dark(red, red)) {
+      {block};
+    }
+  }
+  else {
+    {block};
+  }
+}
+
 sidebar() {
   if (($scheme == 'Muse') or ($scheme == 'Mist')) {
     {block}


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to NexT code! Before you open the pull request, please:

1. Make the tests to confirm that the changes are compatible with PJAX, Dark Mode and all four schemes of NexT (Muse, Mist, Pisces and Gemini). For backend code changes, modify or add unit tests if necessary.

2. Break up your pull request into multiple smaller requests if it contains multiple bug fixes or new features. Each pull request should have one bug fix or new feature only for better code maintainability.

3. If possible, please write the pull request description in English.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Remove items that do not apply. For completed items, change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The changes have been tested (for bug fixes / features).
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Improvement.
- [ ] Code style update (e.g. formatting, linting).
- [ ] Refactoring (no changes to functionality and APIs).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations: https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the new behavior?
<!-- Please describe the new behavior of this pull request -->

Add supports for new CSS feature [`light-dark`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark):

https://github.com/user-attachments/assets/3e88c734-c2e6-4d2a-855d-9c33611eb10b

The `Code Block` does not add `light-dark` support since the `highlight.js` and `prism` does not supports it. The `disqusjs` ether because the origin style seems not match to the dark one in this project.

`@supports (color: light-dark(red, red))` is necessary because `post-css` will fallback it to weird implementation, which does not support `prefers-color-scheme`. The `lightdark.check_supports` can control the `@supports` block.

### How to use?

In NexT `_config.yml`:
```yml
# Light-Dark Mode
lightdark:
  enable: true
  # Add @supports (color: light-dark(red, red)) check
  check_supports: true
```
