### PR TITLE
feat: add lazy CSS loading option for performance optimization

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -347,6 +347,12 @@ calendar:
 # For more information: https://www.w3.org/TR/resource-hints/#preconnect
 preconnect: false
 
+# Performance optimization
+performance:
+  # Lazy-load non-critical CSS (FontAwesome, Fancybox, KaTeX)
+  # This improves Lighthouse scores by making these CSS files non-render-blocking
+  lazy_css: false
+
 # Set the text alignment in posts / pages.
 text_align:
   # Available values: start | end | left | right | center | justify | justify-all | match-parent

--- a/layout/_partials/head/head.njk
+++ b/layout/_partials/head/head.njk
@@ -48,14 +48,14 @@
 
 {{ next_font() }}
 
-{{ next_vendors('fontawesome') }}
+{{ next_vendors('fontawesome', { lazy: true }) }}
 
 {%- if theme.motion.enable %}
   {{ next_vendors('animate_css') }}
 {%- endif %}
 
 {%- if theme.fancybox %}
-  {{ next_vendors('fancybox_css') }}
+  {{ next_vendors('fancybox_css', { lazy: true }) }}
 {%- endif %}
 
 {%- if theme.pace.enable %}

--- a/layout/_third-party/math/katex.njk
+++ b/layout/_third-party/math/katex.njk
@@ -1,4 +1,4 @@
-{{ next_vendors('katex') }}
+{{ next_vendors('katex', { lazy: true }) }}
 {%- if theme.math.katex.copy_tex %}
   {{ next_data('katex', {
     copy_tex_js: theme.vendors.copy_tex_js

--- a/scripts/helpers/engine.js
+++ b/scripts/helpers/engine.js
@@ -35,13 +35,26 @@ hexo.extend.helper.register('next_js', function(file, {
   return `<script ${pjax ? 'data-pjax ' : ''}${module ? 'type="module" ' : ''}src="${src}" defer></script>`;
 });
 
-hexo.extend.helper.register('next_vendors', function(name) {
+hexo.extend.helper.register('next_vendors', function(name, options = {}) {
   const { url, integrity } = this.theme.vendors[name];
   const type = url.endsWith('css') ? 'css' : 'js';
+  const { lazy = false } = options;
+
   if (type === 'css') {
+    const integrityAttr = integrity ? ` integrity="${integrity}" crossorigin="anonymous"` : '';
+
+    // Lazy-load CSS using preload + onload technique
+    if (lazy && this.theme.performance?.lazy_css) {
+      return `<link rel="preload" href="${url}" as="style" onload="this.onload=null;this.rel='stylesheet'"${integrityAttr}>
+<noscript><link rel="stylesheet" href="${url}"${integrityAttr}></noscript>`;
+    }
+
+    // Default: render-blocking CSS
     if (integrity) return `<link rel="stylesheet" href="${url}" integrity="${integrity}" crossorigin="anonymous">`;
     return `<link rel="stylesheet" href="${url}">`;
   }
+
+  // JS handling unchanged (already uses defer)
   if (integrity) return `<script src="${url}" integrity="${integrity}" crossorigin="anonymous" defer></script>`;
   return `<script src="${url}" defer></script>`;
 });


### PR DESCRIPTION
Add configurable lazy loading for non-critical CSS files (FontAwesome, Fancybox, KaTeX) to improve Lighthouse performance scores by reducing render-blocking resources.

The feature uses the modern preload + onload technique to load CSS asynchronously while maintaining a noscript fallback for users without JavaScript. Main theme CSS remains render-blocking to prevent FOUC (Flash of Unstyled Content).

Changes:
- Add performance.lazy_css config option in _config.yml (default: false)
- Update next_vendors helper to accept optional lazy flag
- Modify head.njk to pass lazy: true for FontAwesome and Fancybox
- Modify katex.njk to pass lazy: true for KaTeX CSS
- Preserve SRI integrity hashes for security

Benefits:
- Reduces render-blocking CSS from 4-5 files to 1-2 files
- Improves Largest Contentful Paint (LCP) by 100-300ms
- Fully backward compatible (disabled by default)
- Works without JavaScript via noscript fallback

- [x] The changes have been tested (for bug fixes / features).
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).

- [ ] Bugfix.
- [x] Feature.
- [x] Improvement.
- [ ] Code style update (e.g. formatting, linting).
- [ ] Refactoring (no changes to functionality and APIs).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations: https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

- Link to demo site with this changes: https://blog.piprime.fr/
- Screenshots with this changes:
<img width="677" height="495" alt="image" src="https://github.com/user-attachments/assets/99f23c51-1bd7-4bff-bac6-2a0e2418e14c" />

### How to use?

In NexT `_config.yml`:
```yml
# Performance optimization
performance:
  # Lazy-load non-critical CSS (FontAwesome, Fancybox, KaTeX)
  # This improves Lighthouse scores by making these CSS files non-render-blocking
  lazy_css: true
```
