### PR TITLE
fix: Replace deprecated `url.parse()` with WHATWG `URL` API

### DIFF
--- a/scripts/helpers/next-config.js
+++ b/scripts/helpers/next-config.js
@@ -2,15 +2,19 @@
 
 'use strict';
 
-const { parse } = require('url');
-
 /**
  * Export theme config
  */
 hexo.extend.helper.register('next_config', function() {
   const { config, theme, url_for, __ } = this;
+  let hostname = config.url;
+  try {
+    hostname = new URL(config.url).hostname || config.url;
+  } catch (_) {
+    hostname = config.url;
+  }
   const exportConfig = {
-    hostname  : parse(config.url).hostname || config.url,
+    hostname,
     root      : config.root,
     images    : url_for(theme.images),
     scheme    : theme.scheme,

--- a/scripts/helpers/next-config.js
+++ b/scripts/helpers/next-config.js
@@ -7,10 +7,10 @@
  */
 hexo.extend.helper.register('next_config', function() {
   const { config, theme, url_for, __ } = this;
-  let hostname = config.url;
+  let hostname;
   try {
     hostname = new URL(config.url).hostname || config.url;
-  } catch (_) {
+  } catch {
     hostname = config.url;
   }
   const exportConfig = {


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to NexT code! Before you open the pull request, please:

1. Make the tests to confirm that the changes are compatible with PJAX, Dark Mode and all four schemes of NexT (Muse, Mist, Pisces and Gemini). For backend code changes, modify or add unit tests if necessary.

2. Break up your pull request into multiple smaller requests if it contains multiple bug fixes or new features. Each pull request should have one bug fix or new feature only for better code maintainability.

3. If possible, please write the pull request description in English.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Remove items that do not apply. For completed items, change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The changes have been tested (for bug fixes / features).
- [x] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Improvement.
- [ ] Code style update (e.g. formatting, linting).
- [ ] Refactoring (no changes to functionality and APIs).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations: https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Node deprecation warning when `hexo s`:

```
(node:7632) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

Issue resolved:

## What is the new behavior?
<!-- Please describe the new behavior of this pull request -->

No deprecation warning.

- Link to demo site with this changes:
- Screenshots with this changes:

### How to use?

In NexT `_config.yml`:
```yml
Irrelevant.
```
