### PR TITLE
fix: omit integrity hashes for local vendor plugins

### DIFF
--- a/scripts/events/lib/vendors.js
+++ b/scripts/events/lib/vendors.js
@@ -49,7 +49,13 @@ module.exports = hexo => {
     });
     vendors[key] = {
       url      : links[plugins] || links.cdnjs,
-      integrity: value.integrity
+      // Subresource Integrity only adds value for cross-origin CDN assets.
+      // The hashes in _vendors.yml are computed for the CDN builds; when
+      // self-hosting (`plugins: local`) the files are served same-origin and
+      // may differ byte-for-byte from those builds (e.g. a newer bundled
+      // version), so a hardcoded hash would make the browser block them.
+      // Omit integrity for local assets.
+      integrity: plugins === 'local' ? undefined : value.integrity
     };
   }
 };


### PR DESCRIPTION
# fix: omit SRI for local vendor assets

## Problem

When `vendors.plugins: local`, the theme emits the hardcoded `integrity`
hashes from `_vendors.yml` on self-hosted vendor `<link>`/`<script>` tags.
Those hashes are computed for the **CDN** builds. As soon as the locally
bundled files differ byte-for-byte from the CDN build the hash was computed
for. For example when the vendor library is updated independently of the theme,
the browser's Subresource Integrity check fails, blocks every vendor asset,
and the page renders blank.

## Fix

Subresource Integrity only adds value for **cross-origin CDN** assets, where
it protects against a compromised third party. Self-hosted (`local`) files are
served same-origin, so SRI provides little benefit there and is exactly what
breaks.

So in `local` mode we simply **drop `integrity` (and `crossorigin`)** instead
of carrying a hash that can mismatch:

```diff
     vendors[key] = {
       url      : links[plugins] || links.cdnjs,
-      integrity: value.integrity
+      integrity: plugins === 'local' ? undefined : value.integrity
     };
```

The `next_vendors` helper already omits both attributes when the hash is
absent, so no other change is needed. CDN modes are unaffected — they keep
using the hardcoded `_vendors.yml` hashes.

## Notes

- **No plugin change required.** This supersedes the earlier approach in #947
  that computed hashes via `@next-theme/plugins`, so the dependency on
  next-theme/plugins#347 is dropped.
- Touches a single file: `scripts/events/lib/vendors.js`.
- Replaces #947 (the lazy-CSS change from that PR is split into a separate PR).

## Testing

- `vendors.plugins: local` with vendor versions that differ from the CDN
  hashes: assets now load (previously blank page); generated tags carry no
  `integrity`/`crossorigin`.
- `vendors.plugins: cdnjs` (and other CDN providers): unchanged — `integrity`
  and `crossorigin` still emitted from `_vendors.yml`.
