### PR TITLE
feat: lazy-load non-critical vendor CSS

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -347,6 +347,12 @@ calendar:
 # For more information: https://www.w3.org/TR/resource-hints/#preconnect
 preconnect: false
 
+# Performance optimization
+performance:
+  # Lazy-load non-critical CSS (FontAwesome, Fancybox, KaTeX)
+  # This improves Lighthouse scores by making these CSS files non-render-blocking
+  lazy_css: false
+
 # Set the text alignment in posts / pages.
 text_align:
   # Available values: start | end | left | right | center | justify | justify-all | match-parent

--- a/layout/_partials/head/head.njk
+++ b/layout/_partials/head/head.njk
@@ -48,14 +48,14 @@
 
 {{ next_font() }}
 
-{{ next_vendors('fontawesome') }}
+{{ next_vendors('fontawesome', { lazy: true }) }}
 
 {%- if theme.motion.enable %}
   {{ next_vendors('animate_css') }}
 {%- endif %}
 
 {%- if theme.fancybox %}
-  {{ next_vendors('fancybox_css') }}
+  {{ next_vendors('fancybox_css', { lazy: true }) }}
 {%- endif %}
 
 {%- if theme.pace.enable %}

--- a/layout/_third-party/math/katex.njk
+++ b/layout/_third-party/math/katex.njk
@@ -1,4 +1,4 @@
-{{ next_vendors('katex') }}
+{{ next_vendors('katex', { lazy: true }) }}
 {%- if theme.math.katex.copy_tex %}
   {{ next_data('katex', {
     copy_tex_js: theme.vendors.copy_tex_js

--- a/scripts/helpers/engine.js
+++ b/scripts/helpers/engine.js
@@ -35,13 +35,26 @@ hexo.extend.helper.register('next_js', function(file, {
   return `<script ${pjax ? 'data-pjax ' : ''}${module ? 'type="module" ' : ''}src="${src}" defer></script>`;
 });
 
-hexo.extend.helper.register('next_vendors', function(name) {
+hexo.extend.helper.register('next_vendors', function(name, options = {}) {
   const { url, integrity } = this.theme.vendors[name];
   const type = url.endsWith('css') ? 'css' : 'js';
+  const { lazy = false } = options;
+
   if (type === 'css') {
+    const integrityAttr = integrity ? ` integrity="${integrity}" crossorigin="anonymous"` : '';
+
+    // Lazy-load CSS using preload + onload technique
+    if (lazy && this.theme.performance?.lazy_css) {
+      return `<link rel="preload" href="${url}" as="style" onload="this.onload=null;this.rel='stylesheet'"${integrityAttr}>
+<noscript><link rel="stylesheet" href="${url}"${integrityAttr}></noscript>`;
+    }
+
+    // Default: render-blocking CSS
     if (integrity) return `<link rel="stylesheet" href="${url}" integrity="${integrity}" crossorigin="anonymous">`;
     return `<link rel="stylesheet" href="${url}">`;
   }
+
+  // JS handling unchanged (already uses defer)
   if (integrity) return `<script src="${url}" integrity="${integrity}" crossorigin="anonymous" defer></script>`;
   return `<script src="${url}" defer></script>`;
 });


### PR DESCRIPTION
## Motivation

FontAwesome, Fancybox and KaTeX CSS are render-blocking but not needed for
first paint. Loading them eagerly hurts Lighthouse / Core Web Vitals (FCP, LCP)
on pages that don't use them above the fold. This makes those stylesheets
**non-render-blocking** via opt-in lazy loading.

## Changes

- **New opt-in config** (`_config.yml`), disabled by default so behavior is
  unchanged unless enabled:

  ```yaml
  # Performance optimization
  performance:
    # Lazy-load non-critical CSS (FontAwesome, Fancybox, KaTeX)
    # This improves Lighthouse scores by making these CSS files non-render-blocking
    lazy_css: false
  ```

- **`next_vendors` helper** (`scripts/helpers/engine.js`) accepts an options
  object with a `lazy` flag. When `lazy` is set **and** `performance.lazy_css`
  is enabled, the stylesheet is loaded with the standard preload + `onload`
  swap technique, plus a `<noscript>` fallback for JS-disabled clients:

  ```html
  <link rel="preload" href="…" as="style" onload="this.onload=null;this.rel='stylesheet'">
  <noscript><link rel="stylesheet" href="…"></noscript>
  ```

  JS handling is unchanged (it already uses `defer`). Existing `integrity` /
  `crossorigin` attributes are preserved in both the preload and noscript tags.

- **Templates** opt the three non-critical stylesheets in:
  - `layout/_partials/head/head.njk` — `fontawesome`, `fancybox_css`
  - `layout/_third-party/math/katex.njk` — `katex`

## Notes

- Off by default → no change for existing users until `performance.lazy_css: true`.
- Backward compatible: `next_vendors(name)` still works; the options argument
  is optional.
- Split out from #947 so it can be reviewed independently of the SRI fix.

## Testing

- `performance.lazy_css: false` (default): tags render exactly as before
  (render-blocking `<link rel="stylesheet">`).
- `performance.lazy_css: true`: FontAwesome / Fancybox / KaTeX CSS emit the
  `preload` + `onload` swap with a `<noscript>` fallback; styles still apply
  with and without JavaScript.
