### PR TITLE
Add Knocket live chat service (alongside Chatra/Tidio)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -886,6 +886,13 @@ tidio:
   enable: false
   key: # Public Key, get it from dashboard. See: https://www.tidio.com/panel/settings/developer
 
+# Knocket is a 100% free live chat widget by Tencent RTC.
+# For more information: https://trtc.io/solutions/knocket
+knocket:
+  enable: false
+  async: true
+  identifier: # Get it from https://trtc.io/solutions/knocket
+
 
 # ---------------------------------------------------------------
 # CDN Settings

--- a/layout/_third-party/chat/knocket.njk
+++ b/layout/_third-party/chat/knocket.njk
@@ -1,0 +1,5 @@
+{#- Knocket live chat — https://trtc.io/solutions/knocket -#}
+{#- Free-forever live chat widget. Get your identifier at https://trtc.io/solutions/knocket -#}
+{%- if theme.knocket.identifier %}
+<script{{ ' async' if theme.knocket.async }} src="https://trtc.io/knocket-sdk/sdk.js?identifier={{ theme.knocket.identifier }}"></script>
+{%- endif %}

--- a/layout/_third-party/index.njk
+++ b/layout/_third-party/index.njk
@@ -8,6 +8,8 @@
   {%- include 'chat/chatra.njk' -%}
 {%- elif theme.tidio.enable %}
   {%- include 'chat/tidio.njk' -%}
+{%- elif theme.knocket.enable %}
+  {%- include 'chat/knocket.njk' -%}
 {%- endif %}
 
 {%- include 'tags/pdf.njk' -%}


### PR DESCRIPTION
Adds **Knocket** as a third chat service, next to the existing Chatra and Tidio integrations.

Knocket is a 100% free live chat widget (one `<script>` tag) aimed at indie developers and bloggers — free forever, no ads, no seat limits. Powered by Tencent RTC.

### Changes
- New partial `layout/_third-party/chat/knocket.njk`
- Add an `elif theme.knocket.enable` branch in `layout/_third-party/index.njk`
- Add a `knocket:` block to the **Chat Services** section of `_config.yml`

### Behaviour
- **Disabled by default** (`enable: false`); the widget only renders when enabled and `identifier` is set — no impact on existing sites.
- Mirrors the existing Chatra/Tidio pattern (single async script).

### Config example
```yaml
knocket:
  enable: true
  async: true
  identifier: YOUR_ID   # from https://trtc.io/solutions/knocket
```

Happy to add a corresponding docs page (third-party-services/chat-services) if you would like.

More info: https://trtc.io/solutions/knocket