### PR TITLE
docs: add JSDoc type annotations to hexo event scripts

### DIFF
--- a/scripts/events/lib/config.js
+++ b/scripts/events/lib/config.js
@@ -2,6 +2,9 @@
 
 const { deepMerge } = require('hexo-util');
 
+/**
+ * @param {import('hexo')} hexo
+ */
 module.exports = hexo => {
   const data = hexo.locals.get('data');
 

--- a/scripts/events/lib/vendors.js
+++ b/scripts/events/lib/vendors.js
@@ -14,6 +14,9 @@ try {
 const vendorsFile = fs.readFileSync(path.join(__dirname, '../../../_vendors.yml'));
 const dependencies = yaml.load(vendorsFile);
 
+/**
+ * @param {import('hexo')} hexo
+ */
 module.exports = hexo => {
   const { vendors, creative_commons, pace } = hexo.theme.config;
   if (typeof internal === 'function') {


### PR DESCRIPTION
## What
Add JSDoc type annotations for the hexo parameter in configuration and vendors event scripts to improve type safety and enable IntelliSense in IDEs like VS Code.

## Why
This change resolves the target issue or improvement.

## How to test
Verify that the project builds/runs correctly and the specific bug/improvement is addressed.

Fixes #954