### PR TITLE
Disable Fancybox hash handling with PJAX

### DIFF
--- a/source/js/third-party/fancybox.js
+++ b/source/js/third-party/fancybox.js
@@ -31,5 +31,8 @@ document.addEventListener('page:loaded', () => {
     image.wrap(imageWrapLink);
   });
 
-  Fancybox.bind('[data-fancybox]');
+  // Disable hash handling to avoid conflicts with PJAX navigation.
+  Fancybox.bind('[data-fancybox]', {
+    Hash: false
+  });
 });


### PR DESCRIPTION
## Summary

- disable Fancybox hash handling for NexT image galleries
- prevent Fancybox from changing browser history when PJAX is enabled
- document why the Hash plugin is intentionally disabled

## Root cause

Since Fancybox 5.0.32, the Hash plugin uses browser history when a gallery opens and calls `history.back()` when it closes. NexT's PJAX `popstate` handler treats that history change as navigation, reloads the current page, and can restore the initial scroll position instead of the reader's position.

Disabling the Hash plugin prevents that history entry and the resulting PJAX navigation. Core Fancybox behavior remains available; only per-image URL hashes and deep links are removed.

Fixes #905
See also https://github.com/theme-next/hexo-theme-next/issues/1059

## Validation

- `npx eslint source/js/third-party/fancybox.js`
- `npm test` (60 passing)
- `npx hexo generate`
