### PR TITLE
Fix TOC height calculation for wrapped headings

### DIFF
--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -336,8 +336,6 @@ NexT.utils = {
     const target = navItemList[index];
     if (!target || target.classList.contains('active-current')) return;
 
-    const singleHeight = navItemList[navItemList.length - 1].offsetHeight;
-
     nav.querySelectorAll('.active').forEach(navItem => {
       navItem.classList.remove('active', 'active-current');
     });
@@ -350,9 +348,13 @@ NexT.utils = {
       if (activateEle.classList.contains('nav-item')) {
         activateEle.classList.add('active');
       } else { // .nav-child or .nav
-        // scrollHeight isn't reliable for transitioning child items.
+        // Exclude nested lists so each item's own wrapped row is counted once.
+        const listItemHeight = [...activateEle.children].reduce((height, navItem) => {
+          const navChild = [...navItem.children].find(element => element.classList.contains('nav-child'));
+          return height + navItem.getBoundingClientRect().height - (navChild?.getBoundingClientRect().height || 0);
+        }, 0);
         // The last nav-item in a list has a margin-bottom of 5px.
-        navChildHeight += (singleHeight * activateEle.childElementCount) + 5;
+        navChildHeight += listItemHeight + 5;
         activateEle.style.setProperty('--height', `${navChildHeight}px`);
       }
       activateEle = activateEle.parentElement;


### PR DESCRIPTION
## What is the current behavior?

When `toc.wrap` is enabled, TOC entries can have different rendered heights. However, `activateNavByIndex` uses the height of the final TOC item as `singleHeight` and assumes every item has that same height.

The resulting `--height` can be smaller than the wrapped content. Since `.nav-child` uses `overflow: hidden`, later headings are clipped even though they are present in the generated HTML.

Fixes #772.

## What is the new behavior?

Calculate the rendered height of each direct TOC item instead of multiplying a single assumed height. Nested child lists are subtracted so that each item's own wrapped row is counted exactly once.

This keeps the existing height transition and does not depend on the experimental `calc-size()` CSS function.

## Validation

- Reproduced with Hexo 7.1.1, `hexo-renderer-pandoc` 0.4.0, Gemini, and `toc.wrap: true`
- Exact issue example: calculated height changed from 105px to 156.17px, making all four child headings fully visible
- Verified a wrapped H2-H6 nested TOC path
- `eslint source/js/utils.js`
- `npm test`: 59 passing
