### PR TITLE
Fix 1px scroll offset on page navigation when Pjax is enabled

### DIFF
--- a/source/js/pjax.js
+++ b/source/js/pjax.js
@@ -27,7 +27,7 @@ const pjax = new Pjax({
   analytics: false,
   cacheBust: false,
   // scrollTo accepts a number (vertical offset), a number array ([x, y]), or false (do not scroll).
-  scrollTo: CONFIG.bookmark.enable ? false : 0
+  scrollTo : CONFIG.bookmark.enable ? false : 0
 });
 
 document.addEventListener('pjax:success', () => {

--- a/source/js/pjax.js
+++ b/source/js/pjax.js
@@ -26,7 +26,8 @@ const pjax = new Pjax({
   },
   analytics: false,
   cacheBust: false,
-  scrollTo : !CONFIG.bookmark.enable
+  // scrollTo accepts a number (vertical offset), a number array ([x, y]), or false (do not scroll).
+  scrollTo: CONFIG.bookmark.enable ? false : 0
 });
 
 document.addEventListener('pjax:success', () => {


### PR DESCRIPTION
## PR Checklist
- [x] The changes have been tested (for bug fixes / features).
- [ ] [Docs](https://github.com/next-theme/theme-next-docs/tree/master/source/docs) in [NexT website](https://theme-next.js.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/next-theme/theme-next-docs/tree/master/source/docs and create PR with this changes here: https://github.com/next-theme/theme-next-docs/pulls -->

## PR Type
- [x] Bugfix.
- [ ] Feature.
- [ ] Improvement.
- [ ] Code style update (e.g. formatting, linting).
- [ ] Refactoring (no changes to functionality and APIs).
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations: https://crowdin.com/project/hexo-theme-next -->
- [ ] Other... Please describe:

## What is the current behavior?

When PJAX is enabled and the bookmark feature is disabled, navigating to another page scrolls the page to a vertical offset of `1px` instead of the top.

This happens because the current configuration passes `true` to the `scrollTo` option:

```js
scrollTo: !CONFIG.bookmark.enable
```
The PJAX library expects scrollTo to be a number, a coordinate array, or false. It eventually passes true to window.scrollTo(), where true is converted to the numeric value 1.

## What is the new behavior?

The scrollTo option now receives an explicit value of the correct type:

- 0 when the bookmark feature is disabled, so PJAX navigation scrolls to the top of the page.
- false when the bookmark feature is enabled, so PJAX does not override bookmark-based scroll restoration.

A comment has also been added to clarify the supported scrollTo value types.

### How to use?

No configuration changes are required. Existing PJAX and bookmark settings continue to work as expected.

In NexT _config.yml:
```
pjax: true
```